### PR TITLE
fix hot code swap for "dispatch!" ; handle nils

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -24,16 +24,17 @@ jobs:
         && git clone https://github.com/calcit-lang/calcit-test.git
 
     - name: "load deps"
-      run: >
-        ci-bin/cr_once --emit-js
-        && yarn
+      run: yarn
 
     - name: "test js"
-      run: target=node yarn webpack && env=ci node js-out/bundle.js
+      run: >
+        ci-bin/cr_once --emit-js --init-fn=respo.test.main/main!
+        && target=node entry=./test.js yarn webpack && node js-out/bundle.js
 
     - name: "build js"
       run: >
-        yarn vite build --base=./
+        ci-bin/cr_once --emit-js
+        && yarn vite build --base=./
 
     - name: Deploy to server
       id: deploy

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -822,12 +822,6 @@
                         |T $ {} (:type :leaf) (:text |[]) (:by |rJoDgvdeG) (:at 1511714117609)
                         |j $ {} (:type :leaf) (:text |render-app!) (:by |rJoDgvdeG) (:at 1511714120365)
                         |r $ {} (:type :leaf) (:text |*store) (:by |rJoDgvdeG) (:at 1511714122091)
-                |x $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1610285329541)
-                  :data $ {}
-                    |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610285329864) (:text |[])
-                    |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610285336765) (:text |respo.test.main)
-                    |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610285339274) (:text |:as)
-                    |v $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610285341457) (:text |respo-test)
                 |y $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1612763207855)
                   :data $ {}
                     |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1612763208165) (:text |[])
@@ -849,121 +843,104 @@
                   |T $ {} (:type :leaf) (:by |root) (:at 1529814828532) (:text |handle-ssr!)
                   |j $ {} (:type :leaf) (:by |root) (:at 1529814837949) (:text |mount-target)
                   |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1612763814369) (:text |;)
-              |v $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1610285294398)
+              |v $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1511714151201)
                 :data $ {}
-                  |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1610285301056)
+                  |T $ {} (:type :leaf) (:text |let) (:by |rJoDgvdeG) (:at 1511714151642)
+                  |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1511714151901)
                     :data $ {}
-                      |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1511714151201)
+                      |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1511714152077)
                         :data $ {}
-                          |T $ {} (:type :leaf) (:text |let) (:by |rJoDgvdeG) (:at 1511714151642)
-                          |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1511714151901)
+                          |T $ {} (:type :leaf) (:text |raw) (:by |rJoDgvdeG) (:at 1511714159309)
+                          |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1511714159624)
                             :data $ {}
-                              |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1511714152077)
-                                :data $ {}
-                                  |T $ {} (:type :leaf) (:text |raw) (:by |rJoDgvdeG) (:at 1511714159309)
-                                  |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1511714159624)
-                                    :data $ {}
-                                      |T $ {} (:type :leaf) (:text |.getItem) (:by |rJoDgvdeG) (:at 1511714160896)
-                                      |j $ {} (:type :leaf) (:text |js/window.localStorage) (:by |rJoDgvdeG) (:at 1511714167059)
-                                      |r $ {} (:type :leaf) (:text ||respo.calcit) (:by |rJoDgvdeG) (:at 1610378538280)
-                          |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1511714171488)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:text |if) (:by |rJoDgvdeG) (:at 1511714172059)
-                              |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1511714172408)
-                                :data $ {}
-                                  |T $ {} (:type :leaf) (:text |some?) (:by |rJoDgvdeG) (:at 1511714173139)
-                                  |j $ {} (:type :leaf) (:text |raw) (:by |rJoDgvdeG) (:at 1511714174088)
-                              |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1511714174658)
-                                :data $ {}
-                                  |T $ {} (:type :leaf) (:text |swap!) (:by |rJoDgvdeG) (:at 1511714175868)
-                                  |j $ {} (:type :leaf) (:text |*store) (:by |rJoDgvdeG) (:at 1511714177637)
-                                  |r $ {} (:type :leaf) (:text |assoc) (:by |rJoDgvdeG) (:at 1511714178943)
-                                  |v $ {} (:type :leaf) (:text |:tasks) (:by |rJoDgvdeG) (:at 1511714180772)
-                                  |x $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1610378094696)
-                                    :data $ {}
-                                      |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1610378086008)
-                                        :data $ {}
-                                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610378042977) (:text |raw)
-                                          |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610378088124) (:text |js/JSON.parse)
-                                      |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610378095422) (:text |extract-cirru-edn)
-                          |v $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1511714188800)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:text |render-app!) (:by |rJoDgvdeG) (:at 1511714191933)
-                              |j $ {} (:type :leaf) (:text |mount-target) (:by |rJoDgvdeG) (:at 1511714194378)
-                          |x $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1511714210559)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:text |add-watch) (:by |rJoDgvdeG) (:at 1511714197749)
-                              |j $ {} (:type :leaf) (:text |*store) (:by |rJoDgvdeG) (:at 1511714217070)
-                              |r $ {} (:type :leaf) (:text |:rerender) (:by |rJoDgvdeG) (:at 1511714219489)
-                              |v $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1612347101304)
-                                :data $ {}
-                                  |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1511714220597)
-                                    :data $ {}
-                                      |j $ {} (:type :leaf) (:text |render-app!) (:by |rJoDgvdeG) (:at 1511714232501)
-                                      |r $ {} (:type :leaf) (:text |mount-target) (:by |rJoDgvdeG) (:at 1511714235679)
-                                  |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1612347101873) (:text |fn)
-                                  |L $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1612347102100)
-                                    :data $ {}
-                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1612347103379) (:text |store)
-                                      |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1612347104458) (:text |prev)
-                          |y $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1511714240706)
-                            :data $ {}
-                              |D $ {} (:type :leaf) (:text |;) (:by |rJoDgvdeG) (:at 1511714734746)
-                              |T $ {} (:type :leaf) (:text |reset!) (:by |rJoDgvdeG) (:at 1511714243683)
-                              |j $ {} (:type :leaf) (:text |*changes-logger) (:by |rJoDgvdeG) (:at 1511714251576)
-                              |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1511714252645)
-                                :data $ {}
-                                  |T $ {} (:type :leaf) (:text |fn) (:by |rJoDgvdeG) (:at 1511714260040)
-                                  |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1511714260344)
-                                    :data $ {}
-                                      |T $ {} (:type :leaf) (:text |old-tree) (:by |rJoDgvdeG) (:at 1511714261804)
-                                      |j $ {} (:type :leaf) (:text |new-tree) (:by |rJoDgvdeG) (:at 1511714263034)
-                                      |r $ {} (:type :leaf) (:text |changes) (:by |rJoDgvdeG) (:at 1511714264193)
-                                  |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1511714265521)
-                                    :data $ {}
-                                      |j $ {} (:type :leaf) (:text |js/console.log) (:by |rJoDgvdeG) (:at 1612761921981)
-                                      |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1511714268749)
-                                        :data $ {}
-                                          |T $ {} (:type :leaf) (:text |to-js-data) (:by |rJoDgvdeG) (:at 1612761919364)
-                                          |j $ {} (:type :leaf) (:text |changes) (:by |rJoDgvdeG) (:at 1511714272165)
-                          |yT $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1511714274084)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:text |println) (:by |rJoDgvdeG) (:at 1511714275046)
-                              |j $ {} (:type :leaf) (:text ||Loaded.) (:by |rJoDgvdeG) (:at 1511714279547)
-                              |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1511714280283)
-                                :data $ {}
-                                  |T $ {} (:type :leaf) (:text |.now) (:by |rJoDgvdeG) (:at 1511714280985)
-                                  |j $ {} (:type :leaf) (:text |js/performance) (:by |rJoDgvdeG) (:at 1511714286951)
-                      |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610285301954) (:text |do)
-                      |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1610285304683)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610285304683) (:text |aset)
-                          |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610285304683) (:text |js/window)
-                          |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610285304683) (:text ||onbeforeunload)
-                          |v $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1612347118871)
-                            :data $ {}
-                              |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1612347121576)
-                                :data $ {}
-                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610285304683) (:text |save-store!)
-                              |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1612347119459) (:text |fn)
-                              |L $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1612347119841)
-                                :data $ {}
-                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1612347120601) (:text |event)
-                  |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610285295004) (:text |if)
-                  |L $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1610291260262)
+                              |T $ {} (:type :leaf) (:text |.getItem) (:by |rJoDgvdeG) (:at 1511714160896)
+                              |j $ {} (:type :leaf) (:text |js/window.localStorage) (:by |rJoDgvdeG) (:at 1511714167059)
+                              |r $ {} (:type :leaf) (:text ||respo.calcit) (:by |rJoDgvdeG) (:at 1610378538280)
+                  |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1511714171488)
                     :data $ {}
-                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610291261944) (:text |=)
-                      |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610291710142) (:text "|\"ci")
-                      |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1610291267604)
+                      |T $ {} (:type :leaf) (:text |if) (:by |rJoDgvdeG) (:at 1511714172059)
+                      |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1511714172408)
                         :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610291269049) (:text |get-env)
-                          |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610291708107) (:text "|\"env")
-                  |P $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1610291280695)
+                          |T $ {} (:type :leaf) (:text |some?) (:by |rJoDgvdeG) (:at 1511714173139)
+                          |j $ {} (:type :leaf) (:text |raw) (:by |rJoDgvdeG) (:at 1511714174088)
+                      |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1511714174658)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:text |swap!) (:by |rJoDgvdeG) (:at 1511714175868)
+                          |j $ {} (:type :leaf) (:text |*store) (:by |rJoDgvdeG) (:at 1511714177637)
+                          |r $ {} (:type :leaf) (:text |assoc) (:by |rJoDgvdeG) (:at 1511714178943)
+                          |v $ {} (:type :leaf) (:text |:tasks) (:by |rJoDgvdeG) (:at 1511714180772)
+                          |x $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1610378094696)
+                            :data $ {}
+                              |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1610378086008)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610378042977) (:text |raw)
+                                  |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610378088124) (:text |js/JSON.parse)
+                              |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610378095422) (:text |extract-cirru-edn)
+                  |v $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1511714188800)
                     :data $ {}
-                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610291280695) (:text |respo-test/main!)
+                      |T $ {} (:type :leaf) (:text |render-app!) (:by |rJoDgvdeG) (:at 1511714191933)
+                      |j $ {} (:type :leaf) (:text |mount-target) (:by |rJoDgvdeG) (:at 1511714194378)
+                  |x $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1511714210559)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:text |add-watch) (:by |rJoDgvdeG) (:at 1511714197749)
+                      |j $ {} (:type :leaf) (:text |*store) (:by |rJoDgvdeG) (:at 1511714217070)
+                      |r $ {} (:type :leaf) (:text |:rerender) (:by |rJoDgvdeG) (:at 1511714219489)
+                      |v $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1612347101304)
+                        :data $ {}
+                          |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1511714220597)
+                            :data $ {}
+                              |j $ {} (:type :leaf) (:text |render-app!) (:by |rJoDgvdeG) (:at 1511714232501)
+                              |r $ {} (:type :leaf) (:text |mount-target) (:by |rJoDgvdeG) (:at 1511714235679)
+                          |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1612347101873) (:text |fn)
+                          |L $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1612347102100)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1612347103379) (:text |store)
+                              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1612347104458) (:text |prev)
+                  |y $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1511714240706)
+                    :data $ {}
+                      |D $ {} (:type :leaf) (:text |;) (:by |rJoDgvdeG) (:at 1511714734746)
+                      |T $ {} (:type :leaf) (:text |reset!) (:by |rJoDgvdeG) (:at 1511714243683)
+                      |j $ {} (:type :leaf) (:text |*changes-logger) (:by |rJoDgvdeG) (:at 1511714251576)
+                      |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1511714252645)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:text |fn) (:by |rJoDgvdeG) (:at 1511714260040)
+                          |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1511714260344)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:text |old-tree) (:by |rJoDgvdeG) (:at 1511714261804)
+                              |j $ {} (:type :leaf) (:text |new-tree) (:by |rJoDgvdeG) (:at 1511714263034)
+                              |r $ {} (:type :leaf) (:text |changes) (:by |rJoDgvdeG) (:at 1511714264193)
+                          |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1511714265521)
+                            :data $ {}
+                              |j $ {} (:type :leaf) (:text |js/console.log) (:by |rJoDgvdeG) (:at 1612761921981)
+                              |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1511714268749)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:text |to-js-data) (:by |rJoDgvdeG) (:at 1612761919364)
+                                  |j $ {} (:type :leaf) (:text |changes) (:by |rJoDgvdeG) (:at 1511714272165)
+                  |yT $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1511714274084)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:text |println) (:by |rJoDgvdeG) (:at 1511714275046)
+                      |j $ {} (:type :leaf) (:text ||Loaded.) (:by |rJoDgvdeG) (:at 1511714279547)
+                      |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1511714280283)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:text |.now) (:by |rJoDgvdeG) (:at 1511714280985)
+                          |j $ {} (:type :leaf) (:text |js/performance) (:by |rJoDgvdeG) (:at 1511714286951)
               |u $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1615274283893)
                 :data $ {}
                   |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1615274288270) (:text |load-console-formatter!)
+              |x $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1610285304683)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610285304683) (:text |aset)
+                  |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610285304683) (:text |js/window)
+                  |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610285304683) (:text ||onbeforeunload)
+                  |v $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1612347118871)
+                    :data $ {}
+                      |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1612347121576)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610285304683) (:text |save-store!)
+                      |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1612347119459) (:text |fn)
+                      |L $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1612347119841)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1612347120601) (:text |event)
           |mount-target $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1511714063789)
             :data $ {}
               |T $ {} (:type :leaf) (:text |def) (:by |rJoDgvdeG) (:at 1511714126882)

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -3134,112 +3134,122 @@
               |r $ {} (:type :expr) (:by |root) (:at 1513782743303)
                 :data $ {}
                   |T $ {} (:type :leaf) (:text |props) (:by |root) (:at 1513782746280)
-              |v $ {} (:type :expr) (:by |root) (:at 1513782746786)
+              |v $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1615647772733)
                 :data $ {}
-                  |T $ {} (:type :leaf) (:text |merge) (:by |root) (:at 1513784377351)
-                  |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1610188529146)
+                  |T $ {} (:type :expr) (:by |root) (:at 1513782746786)
                     :data $ {}
-                      |T $ {} (:type :expr) (:by |root) (:at 1513782769122)
+                      |T $ {} (:type :leaf) (:text |merge) (:by |root) (:at 1513784377351)
+                      |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1610188529146)
                         :data $ {}
-                          |T $ {} (:type :leaf) (:text |:on) (:by |root) (:at 1513785453815)
-                          |j $ {} (:type :leaf) (:text |props) (:by |root) (:at 1513782771092)
-                      |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610188531976) (:text |either)
-                      |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1610188532564)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610188532905) (:text |{})
-                  |r $ {} (:type :expr) (:by |root) (:at 1513782771764)
-                    :data $ {}
-                      |T $ {} (:type :leaf) (:text |->>) (:by |root) (:at 1513782778580)
-                      |j $ {} (:type :leaf) (:text |props) (:by |root) (:at 1513782779468)
-                      |r $ {} (:type :expr) (:by |root) (:at 1513782825167)
-                        :data $ {}
-                          |D $ {} (:type :leaf) (:text |filter) (:by |root) (:at 1513782826536)
-                          |T $ {} (:type :expr) (:by |root) (:at 1513782780110)
+                          |T $ {} (:type :expr) (:by |root) (:at 1513782769122)
                             :data $ {}
-                              |T $ {} (:type :leaf) (:text |fn) (:by |root) (:at 1513782781810)
-                              |j $ {} (:type :expr) (:by |root) (:at 1513782782091)
-                                :data $ {}
-                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610030621436) (:text |pair)
-                              |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1610030604312)
-                                :data $ {}
-                                  |T $ {} (:type :expr) (:by |root) (:at 1513782786281)
-                                    :data $ {}
-                                      |T $ {} (:type :leaf) (:text |re-matches) (:by |root) (:at 1513783768094)
-                                      |j $ {} (:type :leaf) (:text ||on-\w+) (:by |root) (:at 1513782817959)
-                                      |r $ {} (:type :expr) (:by |root) (:at 1513782820502)
-                                        :data $ {}
-                                          |T $ {} (:type :leaf) (:text |turn-string) (:by |rJoDgvdeG) (:at 1610188498023)
-                                          |j $ {} (:type :leaf) (:text |k) (:by |root) (:at 1513782821877)
-                                  |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610030605041) (:text |let)
-                                  |L $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1610030605409)
-                                    :data $ {}
-                                      |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1610030606367)
-                                        :data $ {}
-                                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610030610989) (:text |k)
-                                          |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1610030611390)
-                                            :data $ {}
-                                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610030612708) (:text |get)
-                                              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610030613331) (:text |pair)
-                                              |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610030614315) (:text |0)
-                                      |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1610030615493)
-                                        :data $ {}
-                                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610030615648) (:text |v)
-                                          |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1610030616327)
-                                            :data $ {}
-                                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610030616800) (:text |get)
-                                              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610030617558) (:text |pair)
-                                              |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610030618131) (:text |1)
-                      |t $ {} (:type :expr) (:by |root) (:at 1513783773275)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:text |map) (:by |root) (:at 1513783773761)
-                          |j $ {} (:type :expr) (:by |root) (:at 1513783774099)
+                              |T $ {} (:type :leaf) (:text |:on) (:by |root) (:at 1513785453815)
+                              |j $ {} (:type :leaf) (:text |props) (:by |root) (:at 1513782771092)
+                          |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610188531976) (:text |either)
+                          |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1610188532564)
                             :data $ {}
-                              |T $ {} (:type :leaf) (:text |fn) (:by |root) (:at 1513783774679)
-                              |j $ {} (:type :expr) (:by |root) (:at 1513783776268)
+                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610188532905) (:text |{})
+                      |r $ {} (:type :expr) (:by |root) (:at 1513782771764)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:text |->>) (:by |root) (:at 1513782778580)
+                          |j $ {} (:type :leaf) (:text |props) (:by |root) (:at 1513782779468)
+                          |r $ {} (:type :expr) (:by |root) (:at 1513782825167)
+                            :data $ {}
+                              |D $ {} (:type :leaf) (:text |filter) (:by |root) (:at 1513782826536)
+                              |T $ {} (:type :expr) (:by |root) (:at 1513782780110)
                                 :data $ {}
-                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610030633246) (:text |pair)
-                              |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1610030623997)
-                                :data $ {}
-                                  |T $ {} (:type :expr) (:by |root) (:at 1513783780024)
+                                  |T $ {} (:type :leaf) (:text |fn) (:by |root) (:at 1513782781810)
+                                  |j $ {} (:type :expr) (:by |root) (:at 1513782782091)
                                     :data $ {}
-                                      |T $ {} (:type :leaf) (:text |[]) (:by |root) (:at 1513783782433)
-                                      |j $ {} (:type :expr) (:by |root) (:at 1513783784878)
+                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610030621436) (:text |pair)
+                                  |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1610030604312)
+                                    :data $ {}
+                                      |T $ {} (:type :expr) (:by |root) (:at 1513782786281)
                                         :data $ {}
-                                          |T $ {} (:type :leaf) (:text |turn-keyword) (:by |rJoDgvdeG) (:at 1610189334191)
-                                          |j $ {} (:type :expr) (:by |root) (:at 1513783794332)
+                                          |T $ {} (:type :leaf) (:text |re-matches) (:by |root) (:at 1513783768094)
+                                          |j $ {} (:type :leaf) (:text ||on-\w+) (:by |root) (:at 1513782817959)
+                                          |r $ {} (:type :expr) (:by |root) (:at 1513782820502)
                                             :data $ {}
-                                              |D $ {} (:type :leaf) (:text |substr) (:by |rJoDgvdeG) (:at 1610189337928)
-                                              |T $ {} (:type :expr) (:by |root) (:at 1513783787120)
+                                              |T $ {} (:type :leaf) (:text |turn-string) (:by |rJoDgvdeG) (:at 1610188498023)
+                                              |j $ {} (:type :leaf) (:text |k) (:by |root) (:at 1513782821877)
+                                      |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610030605041) (:text |let)
+                                      |L $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1610030605409)
+                                        :data $ {}
+                                          |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1610030606367)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610030610989) (:text |k)
+                                              |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1610030611390)
                                                 :data $ {}
-                                                  |T $ {} (:type :leaf) (:text |turn-string) (:by |rJoDgvdeG) (:at 1610188492570)
-                                                  |j $ {} (:type :leaf) (:text |k) (:by |root) (:at 1513784313055)
-                                              |j $ {} (:type :leaf) (:text |3) (:by |root) (:at 1513783800894)
-                                      |r $ {} (:type :leaf) (:text |v) (:by |root) (:at 1513783791555)
-                                  |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610030624770) (:text |let)
-                                  |L $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1610030624971)
+                                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610030612708) (:text |get)
+                                                  |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610030613331) (:text |pair)
+                                                  |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610030614315) (:text |0)
+                                          |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1610030615493)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610030615648) (:text |v)
+                                              |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1610030616327)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610030616800) (:text |get)
+                                                  |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610030617558) (:text |pair)
+                                                  |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610030618131) (:text |1)
+                          |t $ {} (:type :expr) (:by |root) (:at 1513783773275)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:text |map) (:by |root) (:at 1513783773761)
+                              |j $ {} (:type :expr) (:by |root) (:at 1513783774099)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:text |fn) (:by |root) (:at 1513783774679)
+                                  |j $ {} (:type :expr) (:by |root) (:at 1513783776268)
                                     :data $ {}
-                                      |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1610030625131)
+                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610030633246) (:text |pair)
+                                  |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1610030623997)
+                                    :data $ {}
+                                      |T $ {} (:type :expr) (:by |root) (:at 1513783780024)
                                         :data $ {}
-                                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610030625506) (:text |k)
-                                          |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1610030625947)
+                                          |T $ {} (:type :leaf) (:text |[]) (:by |root) (:at 1513783782433)
+                                          |j $ {} (:type :expr) (:by |root) (:at 1513783784878)
                                             :data $ {}
-                                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610030626439) (:text |get)
-                                              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610030627061) (:text |pair)
-                                              |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610030627505) (:text |0)
-                                      |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1610030628244)
+                                              |T $ {} (:type :leaf) (:text |turn-keyword) (:by |rJoDgvdeG) (:at 1610189334191)
+                                              |j $ {} (:type :expr) (:by |root) (:at 1513783794332)
+                                                :data $ {}
+                                                  |D $ {} (:type :leaf) (:text |substr) (:by |rJoDgvdeG) (:at 1610189337928)
+                                                  |T $ {} (:type :expr) (:by |root) (:at 1513783787120)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:text |turn-string) (:by |rJoDgvdeG) (:at 1610188492570)
+                                                      |j $ {} (:type :leaf) (:text |k) (:by |root) (:at 1513784313055)
+                                                  |j $ {} (:type :leaf) (:text |3) (:by |root) (:at 1513783800894)
+                                          |r $ {} (:type :leaf) (:text |v) (:by |root) (:at 1513783791555)
+                                      |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610030624770) (:text |let)
+                                      |L $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1610030624971)
                                         :data $ {}
-                                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610030628724) (:text |v)
-                                          |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1610030629038)
+                                          |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1610030625131)
                                             :data $ {}
-                                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610030629553) (:text |get)
-                                              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610030630105) (:text |pair)
-                                              |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610030630416) (:text |1)
-                      |v $ {} (:type :expr) (:by |root) (:at 1513782828422)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:text |pairs-map) (:by |rJoDgvdeG) (:at 1610188465961)
-                      |n $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1610188449369)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610188451114) (:text |to-pairs)
+                                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610030625506) (:text |k)
+                                              |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1610030625947)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610030626439) (:text |get)
+                                                  |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610030627061) (:text |pair)
+                                                  |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610030627505) (:text |0)
+                                          |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1610030628244)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610030628724) (:text |v)
+                                              |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1610030629038)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610030629553) (:text |get)
+                                                  |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610030630105) (:text |pair)
+                                                  |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610030630416) (:text |1)
+                          |v $ {} (:type :expr) (:by |root) (:at 1513782828422)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:text |pairs-map) (:by |rJoDgvdeG) (:at 1610188465961)
+                          |n $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1610188449369)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610188451114) (:text |to-pairs)
+                  |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1615647773817) (:text |if)
+                  |L $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1615647775126)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1615647775452) (:text |nil?)
+                      |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1615647776182) (:text |props)
+                  |P $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1615647781902)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1615647782488) (:text |{})
           |val-exists? $ {} (:type :expr) (:by nil) (:at 1504774121421)
             :data $ {}
               |T $ {} (:type :leaf) (:text |defn) (:by |root) (:at 1504774121421)
@@ -9852,7 +9862,7 @@
               |r $ {} (:type :expr) (:by nil) (:at 1504774121421)
                 :data $ {}
                   |T $ {} (:type :leaf) (:text |*global-element) (:by |root) (:at 1504774121421)
-                  |j $ {} (:type :leaf) (:text |dispatch!) (:by |root) (:at 1504774121421)
+                  |j $ {} (:type :leaf) (:text |*dispatch-fn) (:by |rJoDgvdeG) (:at 1615647049712)
               |v $ {} (:type :expr) (:by nil) (:at 1504774121421)
                 :data $ {}
                   |T $ {} (:type :leaf) (:text |fn) (:by |root) (:at 1504774121421)
@@ -9913,32 +9923,44 @@
                                     :data $ {}
                                       |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584871548803) (:text |op)
                                       |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584871557596) (:text |data)
-                                  |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584872185338)
+                                  |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1615647055348)
                                     :data $ {}
-                                      |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584871558547)
+                                      |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584872185338)
                                         :data $ {}
-                                          |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584871560410)
+                                          |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584871558547)
                                             :data $ {}
-                                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610209623492) (:text |list?)
-                                              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584871563045) (:text |op)
-                                          |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584871563843)
-                                            :data $ {}
-                                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584871566681) (:text |dispatch!)
-                                              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584871571390) (:text |:states)
-                                              |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584871573638)
+                                              |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584871560410)
                                                 :data $ {}
-                                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584871573986) (:text |[])
-                                                  |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584871574651) (:text |op)
-                                                  |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584871575952) (:text |data)
-                                      |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584872332376) (:text |cond)
-                                      |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584872190627)
-                                        :data $ {}
-                                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610203158116) (:text |true)
-                                          |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584872192690)
+                                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610209623492) (:text |list?)
+                                                  |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584871563045) (:text |op)
+                                              |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584871563843)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584871566681) (:text |dispatch!)
+                                                  |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584871571390) (:text |:states)
+                                                  |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584871573638)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584871573986) (:text |[])
+                                                      |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584871574651) (:text |op)
+                                                      |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584871575952) (:text |data)
+                                          |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584872332376) (:text |cond)
+                                          |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584872190627)
                                             :data $ {}
-                                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584872192690) (:text |dispatch!)
-                                              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584872192690) (:text |op)
-                                              |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584872192690) (:text |data)
+                                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610203158116) (:text |true)
+                                              |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584872192690)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584872192690) (:text |dispatch!)
+                                                  |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584872192690) (:text |op)
+                                                  |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584872192690) (:text |data)
+                                      |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1615647056049) (:text |let)
+                                      |L $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1615647056462)
+                                        :data $ {}
+                                          |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1615647056611)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1615647058228) (:text |dispatch!)
+                                              |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1615647064531)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1615647062613) (:text |*dispatch-fn)
+                                                  |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1615647066184) (:text |deref)
                       |r $ {} (:type :expr) (:by nil) (:at 1504774121421)
                         :data $ {}
                           |T $ {} (:type :leaf) (:text |if) (:by |root) (:at 1504774121421)
@@ -10593,13 +10615,18 @@
                       |T $ {} (:type :leaf) (:text |rerender-app!) (:by |root) (:at 1504774121421)
                       |j $ {} (:type :leaf) (:text |target) (:by |root) (:at 1504774121421)
                       |r $ {} (:type :leaf) (:text |markup) (:by |root) (:at 1504774121421)
-                      |v $ {} (:type :leaf) (:text |dispatch!) (:by |root) (:at 1504774121421)
+                      |v $ {} (:type :leaf) (:text |*dispatch-fn) (:by |rJoDgvdeG) (:at 1615647033830)
                   |v $ {} (:type :expr) (:by nil) (:at 1504774121421)
                     :data $ {}
                       |T $ {} (:type :leaf) (:text |mount-app!) (:by |root) (:at 1504774121421)
                       |j $ {} (:type :leaf) (:text |target) (:by |root) (:at 1504774121421)
                       |r $ {} (:type :leaf) (:text |markup) (:by |root) (:at 1504774121421)
-                      |v $ {} (:type :leaf) (:text |dispatch!) (:by |root) (:at 1504774121421)
+                      |v $ {} (:type :leaf) (:text |*dispatch-fn) (:by |rJoDgvdeG) (:at 1615647034828)
+              |t $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1615646999982)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1615647005614) (:text |*dispatch-fn)
+                  |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1615647024970) (:text |reset!)
+                  |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1615647029249) (:text |dispatch!)
           |h3 $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1610732339158)
             :data $ {}
               |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610732339158) (:text |defn)
@@ -10628,7 +10655,7 @@
                 :data $ {}
                   |T $ {} (:type :leaf) (:text |target) (:by |root) (:at 1504774121421)
                   |j $ {} (:type :leaf) (:text |element) (:by |rJoDgvdeG) (:at 1612012121603)
-                  |r $ {} (:type :leaf) (:text |dispatch!) (:by |root) (:at 1504774121421)
+                  |r $ {} (:type :leaf) (:text |*dispatch-fn) (:by |rJoDgvdeG) (:at 1615647043808)
               |v $ {} (:type :expr) (:by nil) (:at 1504774121421)
                 :data $ {}
                   |T $ {} (:type :leaf) (:text |assert) (:by |root) (:at 1504774121421)
@@ -10670,7 +10697,7 @@
                             :data $ {}
                               |T $ {} (:type :leaf) (:text |build-deliver-event) (:by |root) (:at 1504774121421)
                               |j $ {} (:type :leaf) (:text |*global-element) (:by |root) (:at 1504774121421)
-                              |r $ {} (:type :leaf) (:text |dispatch!) (:by |root) (:at 1504774121421)
+                              |r $ {} (:type :leaf) (:text |*dispatch-fn) (:by |rJoDgvdeG) (:at 1615647046504)
                       |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1571583125696)
                         :data $ {}
                           |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1571583125696) (:text |*changes)
@@ -10755,76 +10782,96 @@
                   |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1612012648008) (:text |markup)
               |v $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1612012631761)
                 :data $ {}
-                  |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1612012341713)
+                  |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1615647720727)
                     :data $ {}
-                      |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1612012335062)
+                      |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1612012341713)
                         :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1612012335062) (:text |list?)
-                          |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1612012335062) (:text |markup-tree)
-                      |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1612012342264) (:text |if)
-                      |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1612012346347)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1612012346347) (:text |let)
+                          |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1612012335062)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1612012335062) (:text |list?)
+                              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1612012335062) (:text |markup-tree)
                           |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1612012346347)
                             :data $ {}
-                              |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1612012346347)
+                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1612012346347) (:text |let)
+                              |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1612012346347)
                                 :data $ {}
-                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1612012346347) (:text |node-tree)
-                                  |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1612012346347)
+                                  |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1612012346347)
                                     :data $ {}
-                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1612012346347) (:text |filter-first)
+                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1612012346347) (:text |node-tree)
                                       |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1612012346347)
                                         :data $ {}
-                                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1612012346347) (:text |fn)
+                                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1612012346347) (:text |filter-first)
                                           |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1612012346347)
                                             :data $ {}
-                                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1612012346347) (:text |x)
-                                          |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1612012346347)
-                                            :data $ {}
-                                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1612012346347) (:text |and)
+                                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1612012346347) (:text |fn)
                                               |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1612012346347)
                                                 :data $ {}
-                                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1615282871888) (:text |record?)
-                                                  |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1612012346347) (:text |x)
+                                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1612012346347) (:text |x)
                                               |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1612012346347)
                                                 :data $ {}
-                                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1612012346347) (:text |or)
+                                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1612012346347) (:text |and)
                                                   |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1612012346347)
                                                     :data $ {}
-                                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1612012346347) (:text |component?)
+                                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1615282871888) (:text |record?)
                                                       |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1612012346347) (:text |x)
                                                   |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1612012346347)
                                                     :data $ {}
-                                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1612012346347) (:text |element?)
-                                                      |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1612012346347) (:text |x)
-                                      |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1612012346347) (:text |markup-tree)
-                              |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1612012346347)
-                                :data $ {}
-                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1612012346347) (:text |effects-list)
+                                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1612012346347) (:text |or)
+                                                      |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1612012346347)
+                                                        :data $ {}
+                                                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1612012346347) (:text |component?)
+                                                          |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1612012346347) (:text |x)
+                                                      |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1612012346347)
+                                                        :data $ {}
+                                                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1612012346347) (:text |element?)
+                                                          |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1612012346347) (:text |x)
+                                          |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1612012346347) (:text |markup-tree)
                                   |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1612012346347)
                                     :data $ {}
-                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1612012346347) (:text |->>)
-                                      |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1612012346347) (:text |markup-tree)
-                                      |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1612012346347)
+                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1612012346347) (:text |effects-list)
+                                      |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1612012346347)
                                         :data $ {}
-                                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1612012346347) (:text |filter)
-                                          |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1612012346347) (:text |effect?)
-                          |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1612012346347)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1612012346347) (:text |merge)
-                              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1612012346347) (:text |markup)
+                                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1612012346347) (:text |->>)
+                                          |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1612012346347) (:text |markup-tree)
+                                          |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1612012346347)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1612012346347) (:text |filter)
+                                              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1612012346347) (:text |effect?)
                               |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1612012346347)
                                 :data $ {}
-                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1612012346347) (:text |{})
+                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1612012346347) (:text |merge)
+                                  |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1612012346347) (:text |markup)
                                   |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1612012346347)
                                     :data $ {}
-                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1612012346347) (:text |:tree)
-                                      |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1612012372803) (:text |node-tree)
-                                  |v $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1612012346347)
-                                    :data $ {}
-                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1612012346347) (:text |:effects)
-                                      |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1612012346347) (:text |effects-list)
-                      |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1613375529256) (:text |markup)
+                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1612012346347) (:text |{})
+                                      |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1612012346347)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1612012346347) (:text |:tree)
+                                          |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1612012372803) (:text |node-tree)
+                                      |v $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1612012346347)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1612012346347) (:text |:effects)
+                                          |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1612012346347) (:text |effects-list)
+                      |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1615647721566) (:text |cond)
+                      |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1615647723453)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1615647725182) (:text |true)
+                          |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1615647726049) (:text |markup)
+                      |L $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1615647730672)
+                        :data $ {}
+                          |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1615647732016)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1615647732597) (:text |nil?)
+                              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1615647735110) (:text |markup-tree)
+                          |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1615647736114)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1615647736996) (:text |assoc)
+                              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1615647738087) (:text |markup)
+                              |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1615647740189) (:text |:tree)
+                              |v $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1615647740867)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1615647742575) (:text |span)
+                                  |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1615647757967) (:text |nil)
                   |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1612012634157) (:text |&let)
                   |L $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1612012634755)
                     :data $ {}
@@ -11408,7 +11455,7 @@
                 :data $ {}
                   |T $ {} (:type :leaf) (:text |target) (:by |root) (:at 1504774121421)
                   |j $ {} (:type :leaf) (:text |element) (:by |rJoDgvdeG) (:at 1612012096451)
-                  |r $ {} (:type :leaf) (:text |dispatch!) (:by |root) (:at 1504774121421)
+                  |r $ {} (:type :leaf) (:text |*dispatch-fn) (:by |rJoDgvdeG) (:at 1615647037251)
               |v $ {} (:type :expr) (:by nil) (:at 1504774121421)
                 :data $ {}
                   |T $ {} (:type :leaf) (:text |let) (:by |root) (:at 1504774121421)
@@ -11427,7 +11474,7 @@
                             :data $ {}
                               |T $ {} (:type :leaf) (:text |build-deliver-event) (:by |root) (:at 1504774121421)
                               |j $ {} (:type :leaf) (:text |*global-element) (:by |root) (:at 1504774121421)
-                              |r $ {} (:type :leaf) (:text |dispatch!) (:by |root) (:at 1504774121421)
+                              |r $ {} (:type :leaf) (:text |*dispatch-fn) (:by |rJoDgvdeG) (:at 1615647038575)
                       |r $ {} (:type :expr) (:by nil) (:at 1504774121421)
                         :data $ {}
                           |T $ {} (:type :leaf) (:text |*changes) (:by |root) (:at 1504774121421)
@@ -11866,6 +11913,11 @@
               |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1610211744239)
                 :data $ {}
                   |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1610211748401) (:text |[])
+          |*dispatch-fn $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1615647006945)
+            :data $ {}
+              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1615647020524) (:text |defatom)
+              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1615647006945) (:text |*dispatch-fn)
+              |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1615647011835) (:text |nil)
           |defcomp $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1612711003106)
             :data $ {}
               |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1612711003106) (:text |defmacro)
@@ -12355,4 +12407,4 @@
     :init-fn |respo.main/main!
     :compact-output? true
     :storage-key |calcit.cirru
-    :version |0.14.17
+    :version |0.14.18

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -9990,11 +9990,31 @@
                       |T $ {} (:type :expr) (:by nil) (:at 1504774121421)
                         :data $ {}
                           |T $ {} (:type :leaf) (:text |target-element) (:by |root) (:at 1504774121421)
-                          |j $ {} (:type :expr) (:by nil) (:at 1504774121421)
+                          |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1615658647125)
                             :data $ {}
-                              |T $ {} (:type :leaf) (:text |get-markup-at) (:by |root) (:at 1504774121421)
-                              |j $ {} (:type :leaf) (:text |element) (:by |root) (:at 1504774121421)
-                              |r $ {} (:type :leaf) (:text |coord) (:by |root) (:at 1504774121421)
+                              |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1615658648500)
+                                :data $ {}
+                                  |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1615658648675)
+                                    :data $ {}
+                                      |T $ {} (:type :expr) (:by nil) (:at 1504774121421)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:text |get-markup-at) (:by |root) (:at 1504774121421)
+                                          |j $ {} (:type :leaf) (:text |element) (:by |root) (:at 1504774121421)
+                                          |r $ {} (:type :leaf) (:text |coord) (:by |root) (:at 1504774121421)
+                                      |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1615658649281) (:text |m)
+                              |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1615658647886) (:text |let)
+                              |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1615658652275)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1615658652645) (:text |if)
+                                  |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1615658653093)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1615658654877) (:text |component?)
+                                      |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1615658655222) (:text |m)
+                                  |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1615658657693)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1615658658378) (:text |:tree)
+                                      |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1615658658651) (:text |m)
+                                  |v $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1615658660540) (:text |m)
                       |j $ {} (:type :expr) (:by nil) (:at 1504774121421)
                         :data $ {}
                           |T $ {} (:type :leaf) (:text |element-exists?) (:by |root) (:at 1504774121421)

--- a/compact.cirru
+++ b/compact.cirru
@@ -134,25 +134,20 @@
         ns respo.main $ :require
           [] respo.core :refer $ [] *changes-logger clear-cache!
           [] respo.app.core :refer $ [] render-app! *store
-          [] respo.test.main :as respo-test
           [] respo.app.core :refer $ [] handle-ssr!
       :defs $ {}
         |main! $ quote
           defn main! () (; handle-ssr! mount-target) (load-console-formatter!)
-            if
-              = "\"ci" $ get-env "\"env"
-              respo-test/main!
-              do
-                let
-                    raw $ .getItem js/window.localStorage |respo.calcit
-                  if (some? raw)
-                    swap! *store assoc :tasks $ extract-cirru-edn (js/JSON.parse raw)
-                  render-app! mount-target
-                  add-watch *store :rerender $ fn (store prev) (render-app! mount-target)
-                  ; reset! *changes-logger $ fn (old-tree new-tree changes)
-                    js/console.log $ to-js-data changes
-                  println |Loaded. $ .now js/performance
-                aset js/window |onbeforeunload $ fn (event) (save-store!)
+            let
+                raw $ .getItem js/window.localStorage |respo.calcit
+              if (some? raw)
+                swap! *store assoc :tasks $ extract-cirru-edn (js/JSON.parse raw)
+              render-app! mount-target
+              add-watch *store :rerender $ fn (store prev) (render-app! mount-target)
+              ; reset! *changes-logger $ fn (old-tree new-tree changes)
+                js/console.log $ to-js-data changes
+              println |Loaded. $ .now js/performance
+            aset js/window |onbeforeunload $ fn (event) (save-store!)
         |mount-target $ quote
           def mount-target $ if (exists? js/document) (.querySelector js/document |.app) nil
         |reload! $ quote

--- a/compact.cirru
+++ b/compact.cirru
@@ -1483,7 +1483,9 @@
             assert "\"element cannot be nil" $ some? element
             assert "\"coord cannot be nil" $ some? coord
             let
-                target-element $ get-markup-at element coord
+                target-element $ let
+                    m $ get-markup-at element coord
+                  if (component? m) (:tree m) m
                 element-exists? $ some? target-element
               ; println "|target element:" $ pr-str event-name
               if

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "version": "0.14.17",
+  "version": "0.14.18",
   "dependencies": {
-    "@calcit/procs": "^0.2.94"
+    "@calcit/procs": "^0.2.99"
   },
   "devDependencies": {
     "vite": "^2.0.5",
-    "webpack": "^5.24.4",
+    "webpack": "^5.25.0",
     "webpack-cli": "^4.5.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,0 +1,10 @@
+
+import { main_BANG_ } from "./js-out/respo.test.main.js"
+
+main_BANG_()
+
+if (import.meta.hot) {
+  import.meta.hot.accept('./js-out/respo.test.main.js', (main) => {
+    main.reload_BANG_()
+  })
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,8 +3,11 @@ let path = require("path");
 let bundleTarget = process.env.target === "node" ? "node" : "web";
 console.log("Bundle target:", bundleTarget);
 
+let entry = process.env.entry || "./main.js";
+console.log("Entry:", entry);
+
 module.exports = {
-  entry: "./main.js",
+  entry: entry,
   target: bundleTarget,
   mode: "development",
   devtool: "hidden-source-map",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,14 +2,14 @@
 # yarn lockfile v1
 
 
-"@calcit/procs@^0.2.94":
-  version "0.2.94"
-  resolved "https://registry.yarnpkg.com/@calcit/procs/-/procs-0.2.94.tgz#297d8c11d8425ff74645eb53c97c7a6cde322a5d"
-  integrity sha512-PmdnLi9xSF6my4IIosC1dXq2g7SeOGC65Ro5axEUnPd6zjWASboKymKRbzBaReflnesC+07qFeaei+2eCg4r7g==
+"@calcit/procs@^0.2.99":
+  version "0.2.99"
+  resolved "https://registry.yarnpkg.com/@calcit/procs/-/procs-0.2.99.tgz#3959d0ace77305d281e81d6857116d1b14e5dde2"
+  integrity sha512-Oz/QLxK+ZSqyve5bkftoKnURzyrMg1/HAnb4OPb+wp4q7xL9tn/lpL3ttNtjEgSMpo+VawSplglHitMDHTecfg==
   dependencies:
     "@calcit/ternary-tree" "0.0.12"
     "@cirru/parser.ts" "^0.0.1"
-    "@cirru/writer.ts" "^0.1.2"
+    "@cirru/writer.ts" "^0.1.3"
 
 "@calcit/ternary-tree@0.0.12":
   version "0.0.12"
@@ -21,10 +21,10 @@
   resolved "https://registry.yarnpkg.com/@cirru/parser.ts/-/parser.ts-0.0.1.tgz#0870b051bd9f56626759ec22d7a0d5c51b19fe9c"
   integrity sha512-FlUWZ2VqIUK/5cG926CVw9fQ7IGQzRDz8NL2Zc1lK2NyvOltAyZEDxxj/ztWjGOOnetVtM5mDx8rsbsr/SLYhg==
 
-"@cirru/writer.ts@^0.1.2":
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/@cirru/writer.ts/-/writer.ts-0.1.2.tgz#1fa667c2fbdcf083901654b771ed40879d2998e1"
-  integrity sha512-TU1uNk6ei+qsaEY7w9kHyGrAoAYkfDjZu5XyHUjb4i4UvAC+c5EHeA6rVPQL7IhIeFJeFgrnBNb7LizduzWpgA==
+"@cirru/writer.ts@^0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@cirru/writer.ts/-/writer.ts-0.1.3.tgz#5f54bdecaa20ba3dab16cbe6da711854138a9c0a"
+  integrity sha512-vJnhmhm7we5UfQIwmZfQpF3bAFbVybzT6LbmkbQHxgijaQg3gPfNVsnSIa3g3KpmWVtvkzEx+nUy5aMwsJiV1A==
 
 "@discoveryjs/json-ext@^0.5.0":
   version "0.5.2"
@@ -58,9 +58,9 @@
   integrity sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==
 
 "@types/node@*":
-  version "14.14.32"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.32.tgz#90c5c4a8d72bbbfe53033f122341343249183448"
-  integrity sha512-/Ctrftx/zp4m8JOujM5ZhwzlWLx22nbQJiVqz8/zE15gOeEW+uly3FSX4fGFpcfEvFzXcMCJwq9lGVWgyARXhg==
+  version "14.14.34"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.34.tgz#07935194fc049069a1c56c0c274265abeddf88da"
+  integrity sha512-dBPaxocOK6UVyvhbnpFIj2W+S+1cBTkHQbFQfeeJhoKFbzYcVUGHvddeWPSucKATb3F0+pgDq0i6ghEaZjsugA==
 
 "@webassemblyjs/ast@1.11.0":
   version "1.11.0"
@@ -252,9 +252,9 @@ buffer-from@^1.0.0:
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
 
 caniuse-lite@^1.0.30001181:
-  version "1.0.30001197"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001197.tgz#47ad15b977d2f32b3ec2fe2b087e0c50443771db"
-  integrity sha512-8aE+sqBqtXz4G8g35Eg/XEaFr2N7rd/VQ6eABGBmNtcB8cN6qNJhMi6oSFy4UWWZgqgL3filHT8Nha4meu3tsw==
+  version "1.0.30001199"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001199.tgz#062afccaad21023e2e647d767bac4274b8b8fd7f"
+  integrity sha512-ifbK2eChUCFUwGhlEzIoVwzFt1+iriSjyKKFYNfv6hN34483wyWpLLavYQXhnR036LhkdUYaSDpHg1El++VgHQ==
 
 chrome-trace-event@^1.0.2:
   version "1.0.2"
@@ -297,9 +297,9 @@ cross-spawn@^7.0.3:
     which "^2.0.1"
 
 electron-to-chromium@^1.3.649:
-  version "1.3.683"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.683.tgz#2c9ab53ff5275cf3dd49278af714d0f8975204f7"
-  integrity sha512-8mFfiAesXdEdE0DhkMKO7W9U6VU/9T3VTWwZ+4g84/YMP4kgwgFtQgUxuu7FUMcvSeKSNhFQNU+WZ68BQTLT5A==
+  version "1.3.687"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.687.tgz#c336184b7ab70427ffe2ee79eaeaedbc1ad8c374"
+  integrity sha512-IpzksdQNl3wdgkzf7dnA7/v10w0Utf1dF2L+B4+gKrloBrxCut+au+kky3PYvle3RMdSxZP+UiCZtLbcYRxSNQ==
 
 enhanced-resolve@^5.7.0:
   version "5.7.0"
@@ -547,9 +547,9 @@ mimic-fn@^2.1.0:
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
 nanoid@^3.1.20:
-  version "3.1.20"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.20.tgz#badc263c6b1dcf14b71efaa85f6ab4c1d6cfc788"
-  integrity sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw==
+  version "3.1.21"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.21.tgz#25bfee7340ac4185866fbfb2c9006d299da1be7f"
+  integrity sha512-A6oZraK4DJkAOICstsGH98dvycPr/4GGDH7ZWKmMdd3vGcOurZ6JmWFUt0DA5bzrrn2FrUjmv6mFNWvv8jpppA==
 
 neo-async@^2.6.2:
   version "2.6.2"
@@ -624,9 +624,9 @@ pkg-dir@^4.2.0:
     find-up "^4.0.0"
 
 postcss@^8.2.1:
-  version "8.2.7"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.2.7.tgz#48ed8d88b4de10afa0dfd1c3f840aa57b55c4d47"
-  integrity sha512-DsVLH3xJzut+VT+rYr0mtvOtpTjSyqDwPf5EZWXcb0uAKfitGpTY9Ec+afi2+TgdN8rWS9Cs88UDYehKo/RvOw==
+  version "8.2.8"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.2.8.tgz#0b90f9382efda424c4f0f69a2ead6f6830d08ece"
+  integrity sha512-1F0Xb2T21xET7oQV9eKuctbM9S7BC0fetoHCc4H13z0PT6haiRLP4T0ZY4XWh7iLP0usgqykT6p9B2RtOf4FPw==
   dependencies:
     colorette "^1.2.2"
     nanoid "^3.1.20"
@@ -672,9 +672,9 @@ resolve@^1.19.0, resolve@^1.9.0:
     path-parse "^1.0.6"
 
 rollup@^2.38.5:
-  version "2.41.0"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.41.0.tgz#b2a398bbabbf227738dedaef099e494aed468982"
-  integrity sha512-Gk76XHTggulWPH95q8V62bw6uqDH6UGvbD6LOa3QUyhuMF3eOuaeDHR7SLm1T9faitkpNrqzUAVYx47klcMnlA==
+  version "2.41.2"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.41.2.tgz#b7db5cb7c21c2d524e8b26ef39c7e9808a290c7e"
+  integrity sha512-6u8fJJXJx6fmvKrAC9DHYZgONvSkz8S9b/VFBjoQ6dkKdHyPpPbpqiNl2Bao9XBzDHpq672X6sGZ9G1ZBqAHMg==
   optionalDependencies:
     fsevents "~2.3.1"
 
@@ -857,10 +857,10 @@ webpack-sources@^2.1.1:
     source-list-map "^2.0.1"
     source-map "^0.6.1"
 
-webpack@^5.24.4:
-  version "5.24.4"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.24.4.tgz#37d8cf95841dd23c809ea02931294b3455d74a59"
-  integrity sha512-RXOdxF9hFFFhg47BryCgyFrEyyu7Y/75/uiI2DoUiTMqysK+WczVSTppvkR47oZcmI/DPaXCiCiaXBP8QjkNpA==
+webpack@^5.25.0:
+  version "5.25.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.25.0.tgz#f9409977f0f3b6d4b9c4f73adc7d7cb9603a09e9"
+  integrity sha512-jqQZopNCzt9c4K6Qa7j6kIhzHfR9wgF84go58VoNp4JbZrBr2D2l5lcv72CW80yc6NJl8CR6OY8xctnIs0r2uw==
   dependencies:
     "@types/eslint-scope" "^3.7.0"
     "@types/estree" "^0.0.46"


### PR DESCRIPTION
When it was in ClojureScript, the compiler handle hot swapping of functions directly since function are attached to namespace objects which are mutable. Current solution in calcit is basically JavaScript, so I have to introduce an extra atom for passing latest reference of `dispatch!`.
