### PR TITLE
add defstyle for a css-in-js solution

### DIFF
--- a/calcit.cirru
+++ b/calcit.cirru
@@ -1,6 +1,6 @@
 
 {}
-  :configs $ {} (:compact-output? true) (:extension |.cljs) (:init-fn |respo.main/main!) (:output |src) (:port 6001) (:reload-fn |respo.main/reload!) (:storage-key |calcit.cirru) (:version |0.14.37)
+  :configs $ {} (:compact-output? true) (:extension |.cljs) (:init-fn |respo.main/main!) (:output |src) (:port 6001) (:reload-fn |respo.main/reload!) (:storage-key |calcit.cirru) (:version |0.14.38)
     :modules $ [] |memof/compact.cirru |lilac/compact.cirru |calcit-test/compact.cirru
   :entries $ {}
   :ir $ {} (:package |respo)
@@ -193,38 +193,38 @@
                               |j $ {} (:at 1504774121421) (:by nil) (:type :expr)
                                 :data $ {}
                                   |T $ {} (:at 1504774121421) (:by |root) (:text |{}) (:type :leaf)
+                                  |b $ {} (:at 1651180847678) (:by |rJoDgvdeG) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1651180850144) (:by |rJoDgvdeG) (:text |:class-name) (:type :leaf)
+                                      |b $ {} (:at 1651180850506) (:by |rJoDgvdeG) (:text |style-done) (:type :leaf)
                                   |j $ {} (:at 1504774121421) (:by nil) (:type :expr)
                                     :data $ {}
                                       |T $ {} (:at 1504774121421) (:by |root) (:text |:style) (:type :leaf)
                                       |j $ {} (:at 1504774121421) (:by nil) (:type :expr)
                                         :data $ {}
-                                          |T $ {} (:at 1504774121421) (:by |root) (:text |merge) (:type :leaf)
-                                          |j $ {} (:at 1504774121421) (:by |root) (:text |style-done) (:type :leaf)
-                                          |r $ {} (:at 1504774121421) (:by nil) (:type :expr)
+                                          |T $ {} (:at 1504774121421) (:by |root) (:text |{}) (:type :leaf)
+                                          |j $ {} (:at 1504774121421) (:by nil) (:type :expr)
                                             :data $ {}
-                                              |T $ {} (:at 1504774121421) (:by |root) (:text |{}) (:type :leaf)
+                                              |T $ {} (:at 1610447660397) (:by |rJoDgvdeG) (:text "|\"background-color") (:type :leaf)
                                               |j $ {} (:at 1504774121421) (:by nil) (:type :expr)
                                                 :data $ {}
-                                                  |T $ {} (:at 1610447660397) (:by |rJoDgvdeG) (:text "|\"background-color") (:type :leaf)
+                                                  |T $ {} (:at 1504774121421) (:by |root) (:text |if) (:type :leaf)
                                                   |j $ {} (:at 1504774121421) (:by nil) (:type :expr)
                                                     :data $ {}
-                                                      |T $ {} (:at 1504774121421) (:by |root) (:text |if) (:type :leaf)
-                                                      |j $ {} (:at 1504774121421) (:by nil) (:type :expr)
-                                                        :data $ {}
-                                                          |T $ {} (:at 1504774121421) (:by |root) (:text |:done?) (:type :leaf)
-                                                          |j $ {} (:at 1504774121421) (:by |root) (:text |task) (:type :leaf)
-                                                      |r $ {} (:at 1504774121421) (:by nil) (:type :expr)
-                                                        :data $ {}
-                                                          |T $ {} (:at 1504774121421) (:by |root) (:text |hsl) (:type :leaf)
-                                                          |j $ {} (:at 1504774121421) (:by |root) (:text |200) (:type :leaf)
-                                                          |r $ {} (:at 1549948909284) (:by |rJoDgvdeG) (:text |20) (:type :leaf)
-                                                          |v $ {} (:at 1504774121421) (:by |root) (:text |80) (:type :leaf)
-                                                      |v $ {} (:at 1504774121421) (:by nil) (:type :expr)
-                                                        :data $ {}
-                                                          |T $ {} (:at 1504774121421) (:by |root) (:text |hsl) (:type :leaf)
-                                                          |j $ {} (:at 1504774121421) (:by |root) (:text |200) (:type :leaf)
-                                                          |r $ {} (:at 1549948914057) (:by |rJoDgvdeG) (:text |80) (:type :leaf)
-                                                          |v $ {} (:at 1504774121421) (:by |root) (:text |70) (:type :leaf)
+                                                      |T $ {} (:at 1504774121421) (:by |root) (:text |:done?) (:type :leaf)
+                                                      |j $ {} (:at 1504774121421) (:by |root) (:text |task) (:type :leaf)
+                                                  |r $ {} (:at 1504774121421) (:by nil) (:type :expr)
+                                                    :data $ {}
+                                                      |T $ {} (:at 1504774121421) (:by |root) (:text |hsl) (:type :leaf)
+                                                      |j $ {} (:at 1504774121421) (:by |root) (:text |200) (:type :leaf)
+                                                      |r $ {} (:at 1549948909284) (:by |rJoDgvdeG) (:text |20) (:type :leaf)
+                                                      |v $ {} (:at 1504774121421) (:by |root) (:text |80) (:type :leaf)
+                                                  |v $ {} (:at 1504774121421) (:by nil) (:type :expr)
+                                                    :data $ {}
+                                                      |T $ {} (:at 1504774121421) (:by |root) (:text |hsl) (:type :leaf)
+                                                      |j $ {} (:at 1504774121421) (:by |root) (:text |200) (:type :leaf)
+                                                      |r $ {} (:at 1549948914057) (:by |rJoDgvdeG) (:text |80) (:type :leaf)
+                                                      |v $ {} (:at 1504774121421) (:by |root) (:text |70) (:type :leaf)
                                   |r $ {} (:at 1504774121421) (:by nil) (:type :expr)
                                     :data $ {}
                                       |T $ {} (:at 1513785917865) (:by |root) (:text |:on-click) (:type :leaf)
@@ -263,8 +263,8 @@
                                           |j $ {} (:at 1504774121421) (:by |root) (:text |task) (:type :leaf)
                                   |r $ {} (:at 1504774121421) (:by nil) (:type :expr)
                                     :data $ {}
-                                      |T $ {} (:at 1504774121421) (:by |root) (:text |:style) (:type :leaf)
-                                      |j $ {} (:at 1504774121421) (:by |root) (:text |widget/input) (:type :leaf)
+                                      |T $ {} (:at 1651181046534) (:by |rJoDgvdeG) (:text |:class-name) (:type :leaf)
+                                      |j $ {} (:at 1651181043400) (:by |rJoDgvdeG) (:text |widget/style-input) (:type :leaf)
                                   |v $ {} (:at 1505382679150) (:by |root) (:type :expr)
                                     :data $ {}
                                       |T $ {} (:at 1513785912794) (:by |root) (:text |:on-input) (:type :leaf)
@@ -326,8 +326,8 @@
                                       |j $ {} (:at 1504774121421) (:by |root) (:text |state) (:type :leaf)
                                   |r $ {} (:at 1504774121421) (:by nil) (:type :expr)
                                     :data $ {}
-                                      |T $ {} (:at 1504774121421) (:by |root) (:text |:style) (:type :leaf)
-                                      |j $ {} (:at 1504774121421) (:by |root) (:text |widget/input) (:type :leaf)
+                                      |T $ {} (:at 1651181061428) (:by |rJoDgvdeG) (:text |:class-name) (:type :leaf)
+                                      |j $ {} (:at 1651181064305) (:by |rJoDgvdeG) (:text |widget/style-input) (:type :leaf)
                                   |v $ {} (:at 1504774121421) (:by nil) (:type :expr)
                                     :data $ {}
                                       |T $ {} (:at 1513786754951) (:by |root) (:text |:on-input) (:type :leaf)
@@ -357,10 +357,10 @@
                               |j $ {} (:at 1504774121421) (:by nil) (:type :expr)
                                 :data $ {}
                                   |T $ {} (:at 1504774121421) (:by |root) (:text |{}) (:type :leaf)
-                                  |j $ {} (:at 1504774121421) (:by nil) (:type :expr)
+                                  |n $ {} (:at 1651176559735) (:by |rJoDgvdeG) (:type :expr)
                                     :data $ {}
-                                      |T $ {} (:at 1504774121421) (:by |root) (:text |:style) (:type :leaf)
-                                      |j $ {} (:at 1504774121421) (:by |root) (:text |widget/button) (:type :leaf)
+                                      |T $ {} (:at 1651176561461) (:by |rJoDgvdeG) (:text |:class-name) (:type :leaf)
+                                      |b $ {} (:at 1651176583790) (:by |rJoDgvdeG) (:text |widget/style-button) (:type :leaf)
                                   |r $ {} (:at 1515603131600) (:by |root) (:type :expr)
                                     :data $ {}
                                       |D $ {} (:at 1515603136628) (:by |root) (:text |:on-click) (:type :leaf)
@@ -463,31 +463,37 @@
                       |r $ {} (:at 1619539170693) (:by |rJoDgvdeG) (:text |nil) (:type :leaf)
           |style-done $ {} (:at 1504774121421) (:by nil) (:type :expr)
             :data $ {}
-              |T $ {} (:at 1504774121421) (:by |root) (:text |def) (:type :leaf)
+              |T $ {} (:at 1651180825590) (:by |rJoDgvdeG) (:text |defstyle) (:type :leaf)
               |j $ {} (:at 1504774121421) (:by |root) (:text |style-done) (:type :leaf)
-              |r $ {} (:at 1504774121421) (:by nil) (:type :expr)
+              |r $ {} (:at 1651180822430) (:by |rJoDgvdeG) (:type :expr)
                 :data $ {}
-                  |T $ {} (:at 1504774121421) (:by |root) (:text |{}) (:type :leaf)
-                  |j $ {} (:at 1504774121421) (:by nil) (:type :expr)
+                  |D $ {} (:at 1651180832034) (:by |rJoDgvdeG) (:text |{}) (:type :leaf)
+                  |T $ {} (:at 1651180832722) (:by |rJoDgvdeG) (:type :expr)
                     :data $ {}
-                      |T $ {} (:at 1504774121421) (:by |root) (:text |:width) (:type :leaf)
-                      |j $ {} (:at 1504774121421) (:by |root) (:text |32) (:type :leaf)
-                  |r $ {} (:at 1504774121421) (:by nil) (:type :expr)
-                    :data $ {}
-                      |T $ {} (:at 1504774121421) (:by |root) (:text |:height) (:type :leaf)
-                      |j $ {} (:at 1504774121421) (:by |root) (:text |32) (:type :leaf)
-                  |v $ {} (:at 1504774121421) (:by nil) (:type :expr)
-                    :data $ {}
-                      |T $ {} (:at 1504774121421) (:by |root) (:text |:outline) (:type :leaf)
-                      |j $ {} (:at 1504774121421) (:by |root) (:text |:none) (:type :leaf)
-                  |x $ {} (:at 1504774121421) (:by nil) (:type :expr)
-                    :data $ {}
-                      |T $ {} (:at 1504774121421) (:by |root) (:text |:border) (:type :leaf)
-                      |j $ {} (:at 1504774121421) (:by |root) (:text |:none) (:type :leaf)
-                  |y $ {} (:at 1504774121421) (:by nil) (:type :expr)
-                    :data $ {}
-                      |T $ {} (:at 1504774121421) (:by |root) (:text |:vertical-align) (:type :leaf)
-                      |j $ {} (:at 1504774121421) (:by |root) (:text |:middle) (:type :leaf)
+                      |D $ {} (:at 1651180835478) (:by |rJoDgvdeG) (:text "|\"$0") (:type :leaf)
+                      |T $ {} (:at 1504774121421) (:by nil) (:type :expr)
+                        :data $ {}
+                          |T $ {} (:at 1504774121421) (:by |root) (:text |{}) (:type :leaf)
+                          |j $ {} (:at 1504774121421) (:by nil) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1504774121421) (:by |root) (:text |:width) (:type :leaf)
+                              |j $ {} (:at 1504774121421) (:by |root) (:text |32) (:type :leaf)
+                          |r $ {} (:at 1504774121421) (:by nil) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1504774121421) (:by |root) (:text |:height) (:type :leaf)
+                              |j $ {} (:at 1504774121421) (:by |root) (:text |32) (:type :leaf)
+                          |v $ {} (:at 1504774121421) (:by nil) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1504774121421) (:by |root) (:text |:outline) (:type :leaf)
+                              |j $ {} (:at 1504774121421) (:by |root) (:text |:none) (:type :leaf)
+                          |x $ {} (:at 1504774121421) (:by nil) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1504774121421) (:by |root) (:text |:border) (:type :leaf)
+                              |j $ {} (:at 1504774121421) (:by |root) (:text |:none) (:type :leaf)
+                          |y $ {} (:at 1504774121421) (:by nil) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1504774121421) (:by |root) (:text |:vertical-align) (:type :leaf)
+                              |j $ {} (:at 1504774121421) (:by |root) (:text |:middle) (:type :leaf)
           |style-task $ {} (:at 1504774121421) (:by nil) (:type :expr)
             :data $ {}
               |T $ {} (:at 1504774121421) (:by |root) (:text |def) (:type :leaf)
@@ -549,6 +555,13 @@
                     |j $ {} (:at 1504774121421) (:by |root) (:text |respo.app.style.widget) (:type :leaf)
                     |r $ {} (:at 1504774121421) (:by |root) (:text |:as) (:type :leaf)
                     |v $ {} (:at 1504774121421) (:by |root) (:text |widget) (:type :leaf)
+                |z $ {} (:at 1651180811864) (:by |rJoDgvdeG) (:type :expr)
+                  :data $ {}
+                    |T $ {} (:at 1651180814417) (:by |rJoDgvdeG) (:text |respo.css) (:type :leaf)
+                    |b $ {} (:at 1651180816493) (:by |rJoDgvdeG) (:text |:refer) (:type :leaf)
+                    |h $ {} (:at 1651180816793) (:by |rJoDgvdeG) (:type :expr)
+                      :data $ {}
+                        |T $ {} (:at 1651180818894) (:by |rJoDgvdeG) (:text |defstyle) (:type :leaf)
         :proc $ {} (:at 1504774121421) (:by nil) (:type :expr)
           :data $ {}
       |respo.app.comp.todolist $ {}
@@ -645,36 +658,36 @@
                                             :data $ {}
                                               |T $ {} (:at 1610203915704) (:by |rJoDgvdeG) (:text |:draft) (:type :leaf)
                                               |j $ {} (:at 1610203915704) (:by |rJoDgvdeG) (:text |state) (:type :leaf)
+                                      |t $ {} (:at 1651181086495) (:by |rJoDgvdeG) (:type :expr)
+                                        :data $ {}
+                                          |T $ {} (:at 1651181091202) (:by |rJoDgvdeG) (:text |:class-name) (:type :leaf)
+                                          |b $ {} (:at 1651181093107) (:by |rJoDgvdeG) (:text |widget/style-input) (:type :leaf)
                                       |v $ {} (:at 1610203915704) (:by |rJoDgvdeG) (:type :expr)
                                         :data $ {}
                                           |T $ {} (:at 1610203915704) (:by |rJoDgvdeG) (:text |:style) (:type :leaf)
                                           |j $ {} (:at 1610203915704) (:by |rJoDgvdeG) (:type :expr)
                                             :data $ {}
-                                              |T $ {} (:at 1610203915704) (:by |rJoDgvdeG) (:text |merge) (:type :leaf)
-                                              |j $ {} (:at 1610203915704) (:by |rJoDgvdeG) (:text |widget/input) (:type :leaf)
-                                              |r $ {} (:at 1610203915704) (:by |rJoDgvdeG) (:type :expr)
+                                              |T $ {} (:at 1610203915704) (:by |rJoDgvdeG) (:text |{}) (:type :leaf)
+                                              |j $ {} (:at 1610203915704) (:by |rJoDgvdeG) (:type :expr)
                                                 :data $ {}
-                                                  |T $ {} (:at 1610203915704) (:by |rJoDgvdeG) (:text |{}) (:type :leaf)
+                                                  |T $ {} (:at 1610203915704) (:by |rJoDgvdeG) (:text |:width) (:type :leaf)
                                                   |j $ {} (:at 1610203915704) (:by |rJoDgvdeG) (:type :expr)
                                                     :data $ {}
-                                                      |T $ {} (:at 1610203915704) (:by |rJoDgvdeG) (:text |:width) (:type :leaf)
-                                                      |j $ {} (:at 1610203915704) (:by |rJoDgvdeG) (:type :expr)
+                                                      |T $ {} (:at 1610203915704) (:by |rJoDgvdeG) (:text |&max) (:type :leaf)
+                                                      |j $ {} (:at 1610203915704) (:by |rJoDgvdeG) (:text |200) (:type :leaf)
+                                                      |r $ {} (:at 1610203915704) (:by |rJoDgvdeG) (:type :expr)
                                                         :data $ {}
-                                                          |T $ {} (:at 1610203915704) (:by |rJoDgvdeG) (:text |&max) (:type :leaf)
-                                                          |j $ {} (:at 1610203915704) (:by |rJoDgvdeG) (:text |200) (:type :leaf)
+                                                          |T $ {} (:at 1610203915704) (:by |rJoDgvdeG) (:text |+) (:type :leaf)
+                                                          |j $ {} (:at 1610203915704) (:by |rJoDgvdeG) (:text |24) (:type :leaf)
                                                           |r $ {} (:at 1610203915704) (:by |rJoDgvdeG) (:type :expr)
                                                             :data $ {}
-                                                              |T $ {} (:at 1610203915704) (:by |rJoDgvdeG) (:text |+) (:type :leaf)
-                                                              |j $ {} (:at 1610203915704) (:by |rJoDgvdeG) (:text |24) (:type :leaf)
-                                                              |r $ {} (:at 1610203915704) (:by |rJoDgvdeG) (:type :expr)
+                                                              |T $ {} (:at 1610203915704) (:by |rJoDgvdeG) (:text |text-width) (:type :leaf)
+                                                              |j $ {} (:at 1610203915704) (:by |rJoDgvdeG) (:type :expr)
                                                                 :data $ {}
-                                                                  |T $ {} (:at 1610203915704) (:by |rJoDgvdeG) (:text |text-width) (:type :leaf)
-                                                                  |j $ {} (:at 1610203915704) (:by |rJoDgvdeG) (:type :expr)
-                                                                    :data $ {}
-                                                                      |T $ {} (:at 1610203915704) (:by |rJoDgvdeG) (:text |:draft) (:type :leaf)
-                                                                      |j $ {} (:at 1610203915704) (:by |rJoDgvdeG) (:text |state) (:type :leaf)
-                                                                  |r $ {} (:at 1610203915704) (:by |rJoDgvdeG) (:text |16) (:type :leaf)
-                                                                  |v $ {} (:at 1610203915704) (:by |rJoDgvdeG) (:text ||BlinkMacSystemFont) (:type :leaf)
+                                                                  |T $ {} (:at 1610203915704) (:by |rJoDgvdeG) (:text |:draft) (:type :leaf)
+                                                                  |j $ {} (:at 1610203915704) (:by |rJoDgvdeG) (:text |state) (:type :leaf)
+                                                              |r $ {} (:at 1610203915704) (:by |rJoDgvdeG) (:text |16) (:type :leaf)
+                                                              |v $ {} (:at 1610203915704) (:by |rJoDgvdeG) (:text ||BlinkMacSystemFont) (:type :leaf)
                                       |x $ {} (:at 1610203915704) (:by |rJoDgvdeG) (:type :expr)
                                         :data $ {}
                                           |T $ {} (:at 1610203915704) (:by |rJoDgvdeG) (:text |:on-input) (:type :leaf)
@@ -713,10 +726,10 @@
                                   |j $ {} (:at 1610203915704) (:by |rJoDgvdeG) (:type :expr)
                                     :data $ {}
                                       |T $ {} (:at 1610203915704) (:by |rJoDgvdeG) (:text |{}) (:type :leaf)
-                                      |j $ {} (:at 1610203915704) (:by |rJoDgvdeG) (:type :expr)
+                                      |n $ {} (:at 1651175827683) (:by |rJoDgvdeG) (:type :expr)
                                         :data $ {}
-                                          |T $ {} (:at 1610203915704) (:by |rJoDgvdeG) (:text |:style) (:type :leaf)
-                                          |j $ {} (:at 1610203915704) (:by |rJoDgvdeG) (:text |widget/button) (:type :leaf)
+                                          |T $ {} (:at 1651175830269) (:by |rJoDgvdeG) (:text |:class-name) (:type :leaf)
+                                          |b $ {} (:at 1651176756747) (:by |rJoDgvdeG) (:text |widget/style-button) (:type :leaf)
                                       |r $ {} (:at 1610203915704) (:by |rJoDgvdeG) (:type :expr)
                                         :data $ {}
                                           |T $ {} (:at 1610203915704) (:by |rJoDgvdeG) (:text |:on-click) (:type :leaf)
@@ -774,10 +787,10 @@
                                         :data $ {}
                                           |T $ {} (:at 1610203915704) (:by |rJoDgvdeG) (:text |:inner-text) (:type :leaf)
                                           |j $ {} (:at 1610203915704) (:by |rJoDgvdeG) (:text ||Clear) (:type :leaf)
-                                      |r $ {} (:at 1610203915704) (:by |rJoDgvdeG) (:type :expr)
+                                      |r $ {} (:at 1651178815442) (:by |rJoDgvdeG) (:type :expr)
                                         :data $ {}
-                                          |T $ {} (:at 1610203915704) (:by |rJoDgvdeG) (:text |:style) (:type :leaf)
-                                          |j $ {} (:at 1610203915704) (:by |rJoDgvdeG) (:text |widget/button) (:type :leaf)
+                                          |T $ {} (:at 1651178815442) (:by |rJoDgvdeG) (:text |:class-name) (:type :leaf)
+                                          |b $ {} (:at 1651178815442) (:by |rJoDgvdeG) (:text |widget/style-button) (:type :leaf)
                                       |v $ {} (:at 1610203915704) (:by |rJoDgvdeG) (:type :expr)
                                         :data $ {}
                                           |T $ {} (:at 1610203915704) (:by |rJoDgvdeG) (:text |:on-click) (:type :leaf)
@@ -810,10 +823,10 @@
                                       |j $ {} (:at 1610203915704) (:by |rJoDgvdeG) (:type :expr)
                                         :data $ {}
                                           |T $ {} (:at 1610203915704) (:by |rJoDgvdeG) (:text |{}) (:type :leaf)
-                                          |j $ {} (:at 1610203915704) (:by |rJoDgvdeG) (:type :expr)
+                                          |j $ {} (:at 1651178817288) (:by |rJoDgvdeG) (:type :expr)
                                             :data $ {}
-                                              |T $ {} (:at 1610203915704) (:by |rJoDgvdeG) (:text |:style) (:type :leaf)
-                                              |j $ {} (:at 1610203915704) (:by |rJoDgvdeG) (:text |widget/button) (:type :leaf)
+                                              |T $ {} (:at 1651178817288) (:by |rJoDgvdeG) (:text |:class-name) (:type :leaf)
+                                              |b $ {} (:at 1651178817288) (:by |rJoDgvdeG) (:text |widget/style-button) (:type :leaf)
                                           |r $ {} (:at 1610203915704) (:by |rJoDgvdeG) (:type :expr)
                                             :data $ {}
                                               |T $ {} (:at 1610203915704) (:by |rJoDgvdeG) (:text |:on-click) (:type :leaf)
@@ -1720,7 +1733,7 @@
                           |T $ {} (:at 1504774121421) (:by |root) (:text |hsl) (:type :leaf)
                           |j $ {} (:at 1504774121421) (:by |root) (:text |0) (:type :leaf)
                           |r $ {} (:at 1504774121421) (:by |root) (:text |80) (:type :leaf)
-                          |v $ {} (:at 1504774121421) (:by |root) (:text |70) (:type :leaf)
+                          |v $ {} (:at 1651178104512) (:by |rJoDgvdeG) (:text |70.9) (:type :leaf)
                   |yT $ {} (:at 1504774121421) (:by nil) (:type :expr)
                     :data $ {}
                       |T $ {} (:at 1504774121421) (:by |root) (:text |:color) (:type :leaf)
@@ -1738,46 +1751,77 @@
                     :data $ {}
                       |T $ {} (:at 1504774121421) (:by |root) (:text |:line-height) (:type :leaf)
                       |j $ {} (:at 1571551548528) (:by |rJoDgvdeG) (:text "|\"28px") (:type :leaf)
-          |input $ {} (:at 1504774121421) (:by nil) (:type :expr)
+                  |z $ {} (:at 1651176934838) (:by |rJoDgvdeG) (:type :expr)
+                    :data $ {}
+                      |T $ {} (:at 1651178868410) (:by |rJoDgvdeG) (:text |:transition-duration) (:type :leaf)
+                      |b $ {} (:at 1651178874308) (:by |rJoDgvdeG) (:text "|\"200ms") (:type :leaf)
+          |style-button $ {} (:at 1651175842232) (:by |rJoDgvdeG) (:type :expr)
             :data $ {}
-              |T $ {} (:at 1504774121421) (:by |root) (:text |def) (:type :leaf)
-              |j $ {} (:at 1504774121421) (:by |root) (:text |input) (:type :leaf)
-              |r $ {} (:at 1504774121421) (:by nil) (:type :expr)
+              |T $ {} (:at 1651175844155) (:by |rJoDgvdeG) (:text |defstyle) (:type :leaf)
+              |b $ {} (:at 1651176664862) (:by |rJoDgvdeG) (:text |style-button) (:type :leaf)
+              |h $ {} (:at 1651175842232) (:by |rJoDgvdeG) (:type :expr)
                 :data $ {}
-                  |T $ {} (:at 1504774121421) (:by |root) (:text |{}) (:type :leaf)
-                  |j $ {} (:at 1504774121421) (:by nil) (:type :expr)
+                  |T $ {} (:at 1651175846889) (:by |rJoDgvdeG) (:text |{}) (:type :leaf)
+                  |b $ {} (:at 1651175847197) (:by |rJoDgvdeG) (:type :expr)
                     :data $ {}
-                      |T $ {} (:at 1504774121421) (:by |root) (:text |:font-size) (:type :leaf)
-                      |j $ {} (:at 1504774121421) (:by |root) (:text ||16px) (:type :leaf)
-                  |r $ {} (:at 1504774121421) (:by nil) (:type :expr)
+                      |T $ {} (:at 1651175850902) (:by |rJoDgvdeG) (:text "|\"$0") (:type :leaf)
+                      |b $ {} (:at 1651176705567) (:by |rJoDgvdeG) (:text |button) (:type :leaf)
+                  |h $ {} (:at 1651176771327) (:by |rJoDgvdeG) (:type :expr)
                     :data $ {}
-                      |T $ {} (:at 1504774121421) (:by |root) (:text |:line-height) (:type :leaf)
-                      |j $ {} (:at 1504774121421) (:by |root) (:text ||24px) (:type :leaf)
-                  |v $ {} (:at 1504774121421) (:by nil) (:type :expr)
-                    :data $ {}
-                      |T $ {} (:at 1504774121421) (:by |root) (:text |:padding) (:type :leaf)
-                      |j $ {} (:at 1504774121421) (:by |root) (:text "||0px 8px") (:type :leaf)
-                  |x $ {} (:at 1504774121421) (:by nil) (:type :expr)
-                    :data $ {}
-                      |T $ {} (:at 1504774121421) (:by |root) (:text |:outline) (:type :leaf)
-                      |j $ {} (:at 1504774121421) (:by |root) (:text |:none) (:type :leaf)
-                  |y $ {} (:at 1504774121421) (:by nil) (:type :expr)
-                    :data $ {}
-                      |T $ {} (:at 1504774121421) (:by |root) (:text |:min-width) (:type :leaf)
-                      |j $ {} (:at 1504774121421) (:by |root) (:text ||300px) (:type :leaf)
-                  |yT $ {} (:at 1504774121421) (:by nil) (:type :expr)
-                    :data $ {}
-                      |T $ {} (:at 1504774121421) (:by |root) (:text |:background-color) (:type :leaf)
-                      |j $ {} (:at 1504774121421) (:by nil) (:type :expr)
+                      |T $ {} (:at 1651176775569) (:by |rJoDgvdeG) (:text "|\"$0:hover") (:type :leaf)
+                      |b $ {} (:at 1651176781248) (:by |rJoDgvdeG) (:type :expr)
                         :data $ {}
-                          |T $ {} (:at 1504774121421) (:by |root) (:text |hsl) (:type :leaf)
-                          |j $ {} (:at 1504774121421) (:by |root) (:text |0) (:type :leaf)
-                          |r $ {} (:at 1504774121421) (:by |root) (:text |0) (:type :leaf)
-                          |v $ {} (:at 1504774121421) (:by |root) (:text |94) (:type :leaf)
-                  |yj $ {} (:at 1504774121421) (:by nil) (:type :expr)
+                          |T $ {} (:at 1651176781606) (:by |rJoDgvdeG) (:text |{}) (:type :leaf)
+                          |b $ {} (:at 1651176781971) (:by |rJoDgvdeG) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1651176784286) (:by |rJoDgvdeG) (:text |:transform) (:type :leaf)
+                              |b $ {} (:at 1651176923597) (:by |rJoDgvdeG) (:text "|\"scale(1.04)") (:type :leaf)
+          |style-input $ {} (:at 1504774121421) (:by nil) (:type :expr)
+            :data $ {}
+              |T $ {} (:at 1651181023030) (:by |rJoDgvdeG) (:text |defstyle) (:type :leaf)
+              |j $ {} (:at 1651181020406) (:by |rJoDgvdeG) (:text |style-input) (:type :leaf)
+              |r $ {} (:at 1651181031002) (:by |rJoDgvdeG) (:type :expr)
+                :data $ {}
+                  |D $ {} (:at 1651181031867) (:by |rJoDgvdeG) (:text |{}) (:type :leaf)
+                  |T $ {} (:at 1651181033641) (:by |rJoDgvdeG) (:type :expr)
                     :data $ {}
-                      |T $ {} (:at 1504774121421) (:by |root) (:text |:border) (:type :leaf)
-                      |j $ {} (:at 1504774121421) (:by |root) (:text |:none) (:type :leaf)
+                      |D $ {} (:at 1651181035916) (:by |rJoDgvdeG) (:text "|\"$0") (:type :leaf)
+                      |T $ {} (:at 1504774121421) (:by nil) (:type :expr)
+                        :data $ {}
+                          |T $ {} (:at 1504774121421) (:by |root) (:text |{}) (:type :leaf)
+                          |j $ {} (:at 1504774121421) (:by nil) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1504774121421) (:by |root) (:text |:font-size) (:type :leaf)
+                              |j $ {} (:at 1504774121421) (:by |root) (:text ||16px) (:type :leaf)
+                          |r $ {} (:at 1504774121421) (:by nil) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1504774121421) (:by |root) (:text |:line-height) (:type :leaf)
+                              |j $ {} (:at 1504774121421) (:by |root) (:text ||24px) (:type :leaf)
+                          |v $ {} (:at 1504774121421) (:by nil) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1504774121421) (:by |root) (:text |:padding) (:type :leaf)
+                              |j $ {} (:at 1504774121421) (:by |root) (:text "||0px 8px") (:type :leaf)
+                          |x $ {} (:at 1504774121421) (:by nil) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1504774121421) (:by |root) (:text |:outline) (:type :leaf)
+                              |j $ {} (:at 1504774121421) (:by |root) (:text |:none) (:type :leaf)
+                          |y $ {} (:at 1504774121421) (:by nil) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1504774121421) (:by |root) (:text |:min-width) (:type :leaf)
+                              |j $ {} (:at 1504774121421) (:by |root) (:text ||300px) (:type :leaf)
+                          |yT $ {} (:at 1504774121421) (:by nil) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1504774121421) (:by |root) (:text |:background-color) (:type :leaf)
+                              |j $ {} (:at 1504774121421) (:by nil) (:type :expr)
+                                :data $ {}
+                                  |T $ {} (:at 1504774121421) (:by |root) (:text |hsl) (:type :leaf)
+                                  |j $ {} (:at 1504774121421) (:by |root) (:text |0) (:type :leaf)
+                                  |r $ {} (:at 1504774121421) (:by |root) (:text |0) (:type :leaf)
+                                  |v $ {} (:at 1504774121421) (:by |root) (:text |94) (:type :leaf)
+                          |yj $ {} (:at 1504774121421) (:by nil) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1504774121421) (:by |root) (:text |:border) (:type :leaf)
+                              |j $ {} (:at 1504774121421) (:by |root) (:text |:none) (:type :leaf)
         :ns $ {} (:at 1504774121421) (:by nil) (:type :expr)
           :data $ {}
             |T $ {} (:at 1504774121421) (:by |root) (:text |ns) (:type :leaf)
@@ -1792,6 +1836,13 @@
                     |v $ {} (:at 1504774121421) (:by nil) (:type :expr)
                       :data $ {}
                         |j $ {} (:at 1504774121421) (:by |root) (:text |hsl) (:type :leaf)
+                |n $ {} (:at 1651176727189) (:by |rJoDgvdeG) (:type :expr)
+                  :data $ {}
+                    |T $ {} (:at 1651176727189) (:by |rJoDgvdeG) (:text |respo.css) (:type :leaf)
+                    |b $ {} (:at 1651176727189) (:by |rJoDgvdeG) (:text |:refer) (:type :leaf)
+                    |h $ {} (:at 1651176727189) (:by |rJoDgvdeG) (:type :expr)
+                      :data $ {}
+                        |T $ {} (:at 1651176727189) (:by |rJoDgvdeG) (:text |defstyle) (:type :leaf)
         :proc $ {} (:at 1504774121421) (:by nil) (:type :expr)
           :data $ {}
       |respo.app.updater $ {}
@@ -2094,6 +2145,10 @@
                   |j $ {} (:at 1504774121421) (:by nil) (:type :expr)
                     :data $ {}
                       |T $ {} (:at 1504774121421) (:by |root) (:text |{}) (:type :leaf)
+                      |b $ {} (:at 1651181166473) (:by |rJoDgvdeG) (:type :expr)
+                        :data $ {}
+                          |T $ {} (:at 1651181168795) (:by |rJoDgvdeG) (:text |:class-name) (:type :leaf)
+                          |b $ {} (:at 1651181170635) (:by |rJoDgvdeG) (:text |style-data) (:type :leaf)
                       |j $ {} (:at 1504774121421) (:by nil) (:type :expr)
                         :data $ {}
                           |T $ {} (:at 1504774121421) (:by |root) (:text |:inner-text) (:type :leaf)
@@ -2109,11 +2164,7 @@
                       |r $ {} (:at 1504774121421) (:by nil) (:type :expr)
                         :data $ {}
                           |T $ {} (:at 1504774121421) (:by |root) (:text |:style) (:type :leaf)
-                          |j $ {} (:at 1504774121421) (:by nil) (:type :expr)
-                            :data $ {}
-                              |T $ {} (:at 1504774121421) (:by |root) (:text |merge) (:type :leaf)
-                              |j $ {} (:at 1504774121421) (:by |root) (:text |style-data) (:type :leaf)
-                              |r $ {} (:at 1504774121421) (:by |root) (:text |style) (:type :leaf)
+                          |j $ {} (:at 1504774121421) (:by |root) (:text |style) (:type :leaf)
                       |v $ {} (:at 1504774121421) (:by nil) (:type :expr)
                         :data $ {}
                           |T $ {} (:at 1513786986945) (:by |root) (:text |:on-click) (:type :leaf)
@@ -2247,67 +2298,73 @@
                           |j $ {} (:at 1504774121421) (:by |root) (:text |data) (:type :leaf)
           |style-data $ {} (:at 1504774121421) (:by nil) (:type :expr)
             :data $ {}
-              |T $ {} (:at 1504774121421) (:by |root) (:text |def) (:type :leaf)
+              |T $ {} (:at 1651181143824) (:by |rJoDgvdeG) (:text |defstyle) (:type :leaf)
               |j $ {} (:at 1504774121421) (:by |root) (:text |style-data) (:type :leaf)
-              |r $ {} (:at 1504774121421) (:by nil) (:type :expr)
+              |r $ {} (:at 1651181145242) (:by |rJoDgvdeG) (:type :expr)
                 :data $ {}
-                  |T $ {} (:at 1504774121421) (:by |root) (:text |{}) (:type :leaf)
-                  |j $ {} (:at 1504774121421) (:by nil) (:type :expr)
+                  |D $ {} (:at 1651181146289) (:by |rJoDgvdeG) (:text |{}) (:type :leaf)
+                  |T $ {} (:at 1651181147896) (:by |rJoDgvdeG) (:type :expr)
                     :data $ {}
-                      |T $ {} (:at 1504774121421) (:by |root) (:text |:position) (:type :leaf)
-                      |j $ {} (:at 1504774121421) (:by |root) (:text |:absolute) (:type :leaf)
-                  |r $ {} (:at 1504774121421) (:by nil) (:type :expr)
-                    :data $ {}
-                      |T $ {} (:at 1504774121421) (:by |root) (:text |:background-color) (:type :leaf)
-                      |b $ {} (:at 1539015843887) (:by |root) (:text "|\"hsl(240,100%,0%)") (:type :leaf)
-                  |v $ {} (:at 1504774121421) (:by nil) (:type :expr)
-                    :data $ {}
-                      |T $ {} (:at 1504774121421) (:by |root) (:text |:color) (:type :leaf)
-                      |j $ {} (:at 1504774121421) (:by |root) (:text |:white) (:type :leaf)
-                  |x $ {} (:at 1504774121421) (:by nil) (:type :expr)
-                    :data $ {}
-                      |T $ {} (:at 1504774121421) (:by |root) (:text |:opacity) (:type :leaf)
-                      |j $ {} (:at 1504774121421) (:by |root) (:text |0.2) (:type :leaf)
-                  |y $ {} (:at 1504774121421) (:by nil) (:type :expr)
-                    :data $ {}
-                      |T $ {} (:at 1504774121421) (:by |root) (:text |:font-size) (:type :leaf)
-                      |j $ {} (:at 1504774121421) (:by |root) (:text ||12px) (:type :leaf)
-                  |yT $ {} (:at 1504774121421) (:by nil) (:type :expr)
-                    :data $ {}
-                      |T $ {} (:at 1504774121421) (:by |root) (:text |:font-family) (:type :leaf)
-                      |j $ {} (:at 1504774121421) (:by |root) (:text ||Avenir,Verdana) (:type :leaf)
-                  |yj $ {} (:at 1504774121421) (:by nil) (:type :expr)
-                    :data $ {}
-                      |T $ {} (:at 1504774121421) (:by |root) (:text |:line-height) (:type :leaf)
-                      |j $ {} (:at 1613290464569) (:by |rJoDgvdeG) (:text "|\"1.4em") (:type :leaf)
-                  |yr $ {} (:at 1504774121421) (:by nil) (:type :expr)
-                    :data $ {}
-                      |T $ {} (:at 1504774121421) (:by |root) (:text |:padding) (:type :leaf)
-                      |j $ {} (:at 1504774121421) (:by |root) (:text "||2px 6px") (:type :leaf)
-                  |yv $ {} (:at 1504774121421) (:by nil) (:type :expr)
-                    :data $ {}
-                      |T $ {} (:at 1504774121421) (:by |root) (:text |:border-radius) (:type :leaf)
-                      |j $ {} (:at 1504774121421) (:by |root) (:text ||4px) (:type :leaf)
-                  |yx $ {} (:at 1504774121421) (:by nil) (:type :expr)
-                    :data $ {}
-                      |T $ {} (:at 1504774121421) (:by |root) (:text |:max-width) (:type :leaf)
-                      |j $ {} (:at 1504774121421) (:by |root) (:text |160) (:type :leaf)
-                  |yy $ {} (:at 1504774121421) (:by nil) (:type :expr)
-                    :data $ {}
-                      |T $ {} (:at 1504774121421) (:by |root) (:text |:max-height) (:type :leaf)
-                      |j $ {} (:at 1504774121421) (:by |root) (:text |32) (:type :leaf)
-                  |yyT $ {} (:at 1504774121421) (:by nil) (:type :expr)
-                    :data $ {}
-                      |T $ {} (:at 1504774121421) (:by |root) (:text |:white-space) (:type :leaf)
-                      |j $ {} (:at 1504774121421) (:by |root) (:text |:normal) (:type :leaf)
-                  |yyj $ {} (:at 1504774121421) (:by nil) (:type :expr)
-                    :data $ {}
-                      |T $ {} (:at 1504774121421) (:by |root) (:text |:overflow) (:type :leaf)
-                      |j $ {} (:at 1504774121421) (:by |root) (:text |:ellipsis) (:type :leaf)
-                  |yyr $ {} (:at 1504774121421) (:by nil) (:type :expr)
-                    :data $ {}
-                      |T $ {} (:at 1504774121421) (:by |root) (:text |:cursor) (:type :leaf)
-                      |j $ {} (:at 1504774121421) (:by |root) (:text |:default) (:type :leaf)
+                      |D $ {} (:at 1651181149675) (:by |rJoDgvdeG) (:text "|\"$0") (:type :leaf)
+                      |T $ {} (:at 1504774121421) (:by nil) (:type :expr)
+                        :data $ {}
+                          |T $ {} (:at 1504774121421) (:by |root) (:text |{}) (:type :leaf)
+                          |j $ {} (:at 1504774121421) (:by nil) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1504774121421) (:by |root) (:text |:position) (:type :leaf)
+                              |j $ {} (:at 1504774121421) (:by |root) (:text |:absolute) (:type :leaf)
+                          |r $ {} (:at 1504774121421) (:by nil) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1504774121421) (:by |root) (:text |:background-color) (:type :leaf)
+                              |b $ {} (:at 1539015843887) (:by |root) (:text "|\"hsl(240,100%,0%)") (:type :leaf)
+                          |v $ {} (:at 1504774121421) (:by nil) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1504774121421) (:by |root) (:text |:color) (:type :leaf)
+                              |j $ {} (:at 1504774121421) (:by |root) (:text |:white) (:type :leaf)
+                          |x $ {} (:at 1504774121421) (:by nil) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1504774121421) (:by |root) (:text |:opacity) (:type :leaf)
+                              |j $ {} (:at 1504774121421) (:by |root) (:text |0.2) (:type :leaf)
+                          |y $ {} (:at 1504774121421) (:by nil) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1504774121421) (:by |root) (:text |:font-size) (:type :leaf)
+                              |j $ {} (:at 1504774121421) (:by |root) (:text ||12px) (:type :leaf)
+                          |yT $ {} (:at 1504774121421) (:by nil) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1504774121421) (:by |root) (:text |:font-family) (:type :leaf)
+                              |j $ {} (:at 1504774121421) (:by |root) (:text ||Avenir,Verdana) (:type :leaf)
+                          |yj $ {} (:at 1504774121421) (:by nil) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1504774121421) (:by |root) (:text |:line-height) (:type :leaf)
+                              |j $ {} (:at 1613290464569) (:by |rJoDgvdeG) (:text "|\"1.4em") (:type :leaf)
+                          |yr $ {} (:at 1504774121421) (:by nil) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1504774121421) (:by |root) (:text |:padding) (:type :leaf)
+                              |j $ {} (:at 1504774121421) (:by |root) (:text "||2px 6px") (:type :leaf)
+                          |yv $ {} (:at 1504774121421) (:by nil) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1504774121421) (:by |root) (:text |:border-radius) (:type :leaf)
+                              |j $ {} (:at 1504774121421) (:by |root) (:text ||4px) (:type :leaf)
+                          |yx $ {} (:at 1504774121421) (:by nil) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1504774121421) (:by |root) (:text |:max-width) (:type :leaf)
+                              |j $ {} (:at 1504774121421) (:by |root) (:text |160) (:type :leaf)
+                          |yy $ {} (:at 1504774121421) (:by nil) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1504774121421) (:by |root) (:text |:max-height) (:type :leaf)
+                              |j $ {} (:at 1504774121421) (:by |root) (:text |32) (:type :leaf)
+                          |yyT $ {} (:at 1504774121421) (:by nil) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1504774121421) (:by |root) (:text |:white-space) (:type :leaf)
+                              |j $ {} (:at 1504774121421) (:by |root) (:text |:normal) (:type :leaf)
+                          |yyj $ {} (:at 1504774121421) (:by nil) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1504774121421) (:by |root) (:text |:overflow) (:type :leaf)
+                              |j $ {} (:at 1504774121421) (:by |root) (:text |:ellipsis) (:type :leaf)
+                          |yyr $ {} (:at 1504774121421) (:by nil) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1504774121421) (:by |root) (:text |:cursor) (:type :leaf)
+                              |j $ {} (:at 1504774121421) (:by |root) (:text |:default) (:type :leaf)
         :ns $ {} (:at 1504774121421) (:by nil) (:type :expr)
           :data $ {}
             |T $ {} (:at 1504774121421) (:by |root) (:text |ns) (:type :leaf)
@@ -2324,6 +2381,13 @@
                         |j $ {} (:at 1504774121421) (:by |root) (:text |defcomp) (:type :leaf)
                         |r $ {} (:at 1504774121421) (:by |root) (:text |pre) (:type :leaf)
                         |v $ {} (:at 1504774121421) (:by |root) (:text |<>) (:type :leaf)
+                |k $ {} (:at 1651181153297) (:by |rJoDgvdeG) (:type :expr)
+                  :data $ {}
+                    |T $ {} (:at 1651181154597) (:by |rJoDgvdeG) (:text |respo.css) (:type :leaf)
+                    |b $ {} (:at 1651181155371) (:by |rJoDgvdeG) (:text |:refer) (:type :leaf)
+                    |h $ {} (:at 1651181155774) (:by |rJoDgvdeG) (:type :expr)
+                      :data $ {}
+                        |T $ {} (:at 1651181158090) (:by |rJoDgvdeG) (:text |defstyle) (:type :leaf)
         :proc $ {} (:at 1504774121421) (:by nil) (:type :expr)
           :data $ {}
       |respo.comp.space $ {}
@@ -4726,6 +4790,336 @@
                         |T $ {} (:at 1650634136585) (:by |rJoDgvdeG) (:text |reset-memof1-caches!) (:type :leaf)
         :proc $ {} (:at 1504774121421) (:by nil) (:type :expr)
           :data $ {}
+      |respo.css $ {}
+        :configs $ {}
+        :defs $ {}
+          |*style-caches $ {} (:at 1651174578680) (:by |rJoDgvdeG) (:type :expr)
+            :data $ {}
+              |T $ {} (:at 1651174593277) (:by |rJoDgvdeG) (:text |defatom) (:type :leaf)
+              |b $ {} (:at 1651174578680) (:by |rJoDgvdeG) (:text |*style-caches) (:type :leaf)
+              |h $ {} (:at 1651174578680) (:by |rJoDgvdeG) (:type :expr)
+                :data $ {}
+                  |T $ {} (:at 1651174595152) (:by |rJoDgvdeG) (:text |{}) (:type :leaf)
+          |create-style! $ {} (:at 1651174626759) (:by |rJoDgvdeG) (:type :expr)
+            :data $ {}
+              |T $ {} (:at 1651174626759) (:by |rJoDgvdeG) (:text |defn) (:type :leaf)
+              |b $ {} (:at 1651174626759) (:by |rJoDgvdeG) (:text |create-style!) (:type :leaf)
+              |h $ {} (:at 1651174626759) (:by |rJoDgvdeG) (:type :expr)
+                :data $ {}
+                  |T $ {} (:at 1651174970674) (:by |rJoDgvdeG) (:text |style-name) (:type :leaf)
+                  |b $ {} (:at 1651174972502) (:by |rJoDgvdeG) (:text |rules) (:type :leaf)
+              |l $ {} (:at 1651174973342) (:by |rJoDgvdeG) (:type :expr)
+                :data $ {}
+                  |T $ {} (:at 1651174975272) (:by |rJoDgvdeG) (:text |assert) (:type :leaf)
+                  |b $ {} (:at 1651174983001) (:by |rJoDgvdeG) (:text "|\"expected rules in map") (:type :leaf)
+                  |h $ {} (:at 1651175037042) (:by |rJoDgvdeG) (:type :expr)
+                    :data $ {}
+                      |T $ {} (:at 1651175039872) (:by |rJoDgvdeG) (:text |map?) (:type :leaf)
+                      |b $ {} (:at 1651175041527) (:by |rJoDgvdeG) (:text |rules) (:type :leaf)
+              |o $ {} (:at 1651175424571) (:by |rJoDgvdeG) (:type :expr)
+                :data $ {}
+                  |D $ {} (:at 1651175425232) (:by |rJoDgvdeG) (:text |if) (:type :leaf)
+                  |L $ {} (:at 1651175426091) (:by |rJoDgvdeG) (:type :expr)
+                    :data $ {}
+                      |T $ {} (:at 1651175428344) (:by |rJoDgvdeG) (:text |contains?) (:type :leaf)
+                      |b $ {} (:at 1651175431646) (:by |rJoDgvdeG) (:text |@*style-caches) (:type :leaf)
+                      |h $ {} (:at 1651175436475) (:by |rJoDgvdeG) (:text |style-name) (:type :leaf)
+                  |P $ {} (:at 1651175525993) (:by |rJoDgvdeG) (:type :expr)
+                    :data $ {}
+                      |D $ {} (:at 1651175526663) (:by |rJoDgvdeG) (:text |if) (:type :leaf)
+                      |L $ {} (:at 1651175529425) (:by |rJoDgvdeG) (:type :expr)
+                        :data $ {}
+                          |T $ {} (:at 1651175542850) (:by |rJoDgvdeG) (:text |=) (:type :leaf)
+                          |X $ {} (:at 1651175536174) (:by |rJoDgvdeG) (:text |rules) (:type :leaf)
+                          |b $ {} (:at 1651175529425) (:by |rJoDgvdeG) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1651175529425) (:by |rJoDgvdeG) (:text |get-in) (:type :leaf)
+                              |b $ {} (:at 1651175529425) (:by |rJoDgvdeG) (:text |@*style-caches) (:type :leaf)
+                              |h $ {} (:at 1651175529425) (:by |rJoDgvdeG) (:type :expr)
+                                :data $ {}
+                                  |T $ {} (:at 1651175529425) (:by |rJoDgvdeG) (:text |[]) (:type :leaf)
+                                  |b $ {} (:at 1651175529425) (:by |rJoDgvdeG) (:text |style-name) (:type :leaf)
+                                  |h $ {} (:at 1651175529425) (:by |rJoDgvdeG) (:text |:rules) (:type :leaf)
+                      |P $ {} (:at 1651176903256) (:by |rJoDgvdeG) (:text |style-name) (:type :leaf)
+                      |T $ {} (:at 1651175496709) (:by |rJoDgvdeG) (:type :expr)
+                        :data $ {}
+                          |T $ {} (:at 1651175498056) (:by |rJoDgvdeG) (:text |let) (:type :leaf)
+                          |b $ {} (:at 1651175498299) (:by |rJoDgvdeG) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1651175498989) (:by |rJoDgvdeG) (:type :expr)
+                                :data $ {}
+                                  |T $ {} (:at 1651175500615) (:by |rJoDgvdeG) (:text |style-el) (:type :leaf)
+                                  |b $ {} (:at 1651175504489) (:by |rJoDgvdeG) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1651175504489) (:by |rJoDgvdeG) (:text |get-in) (:type :leaf)
+                                      |b $ {} (:at 1651175504489) (:by |rJoDgvdeG) (:text |@*style-caches) (:type :leaf)
+                                      |h $ {} (:at 1651175504489) (:by |rJoDgvdeG) (:type :expr)
+                                        :data $ {}
+                                          |T $ {} (:at 1651175504489) (:by |rJoDgvdeG) (:text |[]) (:type :leaf)
+                                          |b $ {} (:at 1651175504489) (:by |rJoDgvdeG) (:text |style-name) (:type :leaf)
+                                          |h $ {} (:at 1651175506448) (:by |rJoDgvdeG) (:text |:el) (:type :leaf)
+                              |b $ {} (:at 1651175566664) (:by |rJoDgvdeG) (:type :expr)
+                                :data $ {}
+                                  |T $ {} (:at 1651175566664) (:by |rJoDgvdeG) (:text |css-block) (:type :leaf)
+                                  |b $ {} (:at 1651175613769) (:by |rJoDgvdeG) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1651175616415) (:by |rJoDgvdeG) (:text |render-css-block) (:type :leaf)
+                                      |b $ {} (:at 1651175622200) (:by |rJoDgvdeG) (:text |style-name) (:type :leaf)
+                                      |h $ {} (:at 1651175622900) (:by |rJoDgvdeG) (:text |rules) (:type :leaf)
+                          |h $ {} (:at 1651175571619) (:by |rJoDgvdeG) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1651175571619) (:by |rJoDgvdeG) (:text |set!) (:type :leaf)
+                              |b $ {} (:at 1651175571619) (:by |rJoDgvdeG) (:type :expr)
+                                :data $ {}
+                                  |T $ {} (:at 1651175571619) (:by |rJoDgvdeG) (:text |.-innerHTML) (:type :leaf)
+                                  |b $ {} (:at 1651175571619) (:by |rJoDgvdeG) (:text |style-el) (:type :leaf)
+                              |h $ {} (:at 1651175571619) (:by |rJoDgvdeG) (:text |css-block) (:type :leaf)
+                          |l $ {} (:at 1651175578358) (:by |rJoDgvdeG) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1651175578358) (:by |rJoDgvdeG) (:text |swap!) (:type :leaf)
+                              |b $ {} (:at 1651175578358) (:by |rJoDgvdeG) (:text |*style-caches) (:type :leaf)
+                              |h $ {} (:at 1651175580381) (:by |rJoDgvdeG) (:text |assoc-in) (:type :leaf)
+                              |l $ {} (:at 1651175581547) (:by |rJoDgvdeG) (:type :expr)
+                                :data $ {}
+                                  |D $ {} (:at 1651175582171) (:by |rJoDgvdeG) (:text |[]) (:type :leaf)
+                                  |T $ {} (:at 1651175578358) (:by |rJoDgvdeG) (:text |style-name) (:type :leaf)
+                                  |b $ {} (:at 1651175588320) (:by |rJoDgvdeG) (:text |:rules) (:type :leaf)
+                              |o $ {} (:at 1651175590698) (:by |rJoDgvdeG) (:text |rules) (:type :leaf)
+                          |o $ {} (:at 1651176885114) (:by |rJoDgvdeG) (:text |style-name) (:type :leaf)
+                  |T $ {} (:at 1651175240132) (:by |rJoDgvdeG) (:type :expr)
+                    :data $ {}
+                      |D $ {} (:at 1651175240868) (:by |rJoDgvdeG) (:text |let) (:type :leaf)
+                      |T $ {} (:at 1651175242467) (:by |rJoDgvdeG) (:type :expr)
+                        :data $ {}
+                          |T $ {} (:at 1651175242603) (:by |rJoDgvdeG) (:type :expr)
+                            :data $ {}
+                              |D $ {} (:at 1651175256369) (:by |rJoDgvdeG) (:text |css-block) (:type :leaf)
+                              |T $ {} (:at 1651175629714) (:by |rJoDgvdeG) (:type :expr)
+                                :data $ {}
+                                  |T $ {} (:at 1651175629714) (:by |rJoDgvdeG) (:text |render-css-block) (:type :leaf)
+                                  |b $ {} (:at 1651175629714) (:by |rJoDgvdeG) (:text |style-name) (:type :leaf)
+                                  |h $ {} (:at 1651175629714) (:by |rJoDgvdeG) (:text |rules) (:type :leaf)
+                          |b $ {} (:at 1651175284531) (:by |rJoDgvdeG) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1651175287528) (:by |rJoDgvdeG) (:text |style-el) (:type :leaf)
+                              |b $ {} (:at 1651175287942) (:by |rJoDgvdeG) (:type :expr)
+                                :data $ {}
+                                  |T $ {} (:at 1651175294053) (:by |rJoDgvdeG) (:text |js/document.createElement) (:type :leaf)
+                                  |b $ {} (:at 1651175296327) (:by |rJoDgvdeG) (:text "|\"style") (:type :leaf)
+                      |X $ {} (:at 1651175298729) (:by |rJoDgvdeG) (:type :expr)
+                        :data $ {}
+                          |T $ {} (:at 1651175304642) (:by |rJoDgvdeG) (:text |set!) (:type :leaf)
+                          |b $ {} (:at 1651175307704) (:by |rJoDgvdeG) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1651175309690) (:by |rJoDgvdeG) (:text |.-innerHTML) (:type :leaf)
+                              |b $ {} (:at 1651175311488) (:by |rJoDgvdeG) (:text |style-el) (:type :leaf)
+                          |h $ {} (:at 1651175316541) (:by |rJoDgvdeG) (:text |css-block) (:type :leaf)
+                      |Z $ {} (:at 1651175725468) (:by |rJoDgvdeG) (:type :expr)
+                        :data $ {}
+                          |T $ {} (:at 1651175735768) (:by |rJoDgvdeG) (:text |set!) (:type :leaf)
+                          |b $ {} (:at 1651175736230) (:by |rJoDgvdeG) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1651175740907) (:by |rJoDgvdeG) (:text |.-id) (:type :leaf)
+                              |b $ {} (:at 1651175743179) (:by |rJoDgvdeG) (:text |style-el) (:type :leaf)
+                          |h $ {} (:at 1651175745298) (:by |rJoDgvdeG) (:text |style-name) (:type :leaf)
+                      |b $ {} (:at 1651175261628) (:by |rJoDgvdeG) (:type :expr)
+                        :data $ {}
+                          |T $ {} (:at 1651175277547) (:by |rJoDgvdeG) (:text |js/document.head.appendChild) (:type :leaf)
+                          |b $ {} (:at 1651175282810) (:by |rJoDgvdeG) (:text |style-el) (:type :leaf)
+                      |h $ {} (:at 1651175326714) (:by |rJoDgvdeG) (:type :expr)
+                        :data $ {}
+                          |T $ {} (:at 1651175341289) (:by |rJoDgvdeG) (:text |swap!) (:type :leaf)
+                          |b $ {} (:at 1651175347176) (:by |rJoDgvdeG) (:text |*style-caches) (:type :leaf)
+                          |h $ {} (:at 1651175350947) (:by |rJoDgvdeG) (:text |assoc) (:type :leaf)
+                          |l $ {} (:at 1651175359742) (:by |rJoDgvdeG) (:text |style-name) (:type :leaf)
+                          |o $ {} (:at 1651175362547) (:by |rJoDgvdeG) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1651175362851) (:by |rJoDgvdeG) (:text |{}) (:type :leaf)
+                              |b $ {} (:at 1651175363926) (:by |rJoDgvdeG) (:type :expr)
+                                :data $ {}
+                                  |T $ {} (:at 1651175367765) (:by |rJoDgvdeG) (:text |:rules) (:type :leaf)
+                                  |b $ {} (:at 1651175370605) (:by |rJoDgvdeG) (:text |rules) (:type :leaf)
+                              |h $ {} (:at 1651175371708) (:by |rJoDgvdeG) (:type :expr)
+                                :data $ {}
+                                  |T $ {} (:at 1651175374961) (:by |rJoDgvdeG) (:text |:el) (:type :leaf)
+                                  |b $ {} (:at 1651175384722) (:by |rJoDgvdeG) (:text |style-el) (:type :leaf)
+                      |l $ {} (:at 1651176882034) (:by |rJoDgvdeG) (:text |style-name) (:type :leaf)
+          |defstyle $ {} (:at 1651174523252) (:by |rJoDgvdeG) (:type :expr)
+            :data $ {}
+              |T $ {} (:at 1651174631916) (:by |rJoDgvdeG) (:text |defmacro) (:type :leaf)
+              |b $ {} (:at 1651174523252) (:by |rJoDgvdeG) (:text |defstyle) (:type :leaf)
+              |h $ {} (:at 1651174523252) (:by |rJoDgvdeG) (:type :expr)
+                :data $ {}
+                  |T $ {} (:at 1651174665273) (:by |rJoDgvdeG) (:text |style-name) (:type :leaf)
+                  |b $ {} (:at 1651174644648) (:by |rJoDgvdeG) (:text |rules) (:type :leaf)
+              |i $ {} (:at 1651174843100) (:by |rJoDgvdeG) (:type :expr)
+                :data $ {}
+                  |T $ {} (:at 1651174843100) (:by |rJoDgvdeG) (:text |assert) (:type :leaf)
+                  |b $ {} (:at 1651174861992) (:by |rJoDgvdeG) (:text "|\"expected symbol of style-name") (:type :leaf)
+                  |h $ {} (:at 1651174843100) (:by |rJoDgvdeG) (:type :expr)
+                    :data $ {}
+                      |T $ {} (:at 1651174843100) (:by |rJoDgvdeG) (:text |symbol?) (:type :leaf)
+                      |b $ {} (:at 1651175893994) (:by |rJoDgvdeG) (:text |style-name) (:type :leaf)
+              |l $ {} (:at 1651174697214) (:by |rJoDgvdeG) (:type :expr)
+                :data $ {}
+                  |D $ {} (:at 1651174698002) (:by |rJoDgvdeG) (:text |let) (:type :leaf)
+                  |L $ {} (:at 1651174698310) (:by |rJoDgvdeG) (:type :expr)
+                    :data $ {}
+                      |b $ {} (:at 1651174772326) (:by |rJoDgvdeG) (:type :expr)
+                        :data $ {}
+                          |T $ {} (:at 1651180005690) (:by |rJoDgvdeG) (:text |style-name-str) (:type :leaf)
+                          |b $ {} (:at 1651174774495) (:by |rJoDgvdeG) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1651174775125) (:by |rJoDgvdeG) (:text |str) (:type :leaf)
+                              |b $ {} (:at 1651175922028) (:by |rJoDgvdeG) (:type :expr)
+                                :data $ {}
+                                  |D $ {} (:at 1651175924164) (:by |rJoDgvdeG) (:text |turn-string) (:type :leaf)
+                                  |T $ {} (:at 1651174781253) (:by |rJoDgvdeG) (:text |style-name) (:type :leaf)
+                              |e $ {} (:at 1651180054699) (:by |rJoDgvdeG) (:text "|\"__") (:type :leaf)
+                              |j $ {} (:at 1651180059611) (:by |rJoDgvdeG) (:type :expr)
+                                :data $ {}
+                                  |D $ {} (:at 1651180060742) (:by |rJoDgvdeG) (:text |.replace) (:type :leaf)
+                                  |T $ {} (:at 1651180056561) (:by |rJoDgvdeG) (:type :expr)
+                                    :data $ {}
+                                      |D $ {} (:at 1651180058847) (:by |rJoDgvdeG) (:text |turn-string) (:type :leaf)
+                                      |T $ {} (:at 1651180072405) (:by |rJoDgvdeG) (:type :expr)
+                                        :data $ {}
+                                          |D $ {} (:at 1651180073806) (:by |rJoDgvdeG) (:text |:ns) (:type :leaf)
+                                          |T $ {} (:at 1651180055178) (:by |rJoDgvdeG) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1651180434268) (:by |rJoDgvdeG) (:text |&extract-code-into-edn) (:type :leaf)
+                                              |b $ {} (:at 1651180055178) (:by |rJoDgvdeG) (:text |style-name) (:type :leaf)
+                                  |b $ {} (:at 1651180063179) (:by |rJoDgvdeG) (:text "|\".") (:type :leaf)
+                                  |h $ {} (:at 1651180064810) (:by |rJoDgvdeG) (:text "|\"_") (:type :leaf)
+                  |T $ {} (:at 1651174645559) (:by |rJoDgvdeG) (:type :expr)
+                    :data $ {}
+                      |T $ {} (:at 1651174650817) (:by |rJoDgvdeG) (:text |quasiquote) (:type :leaf)
+                      |b $ {} (:at 1651174651752) (:by |rJoDgvdeG) (:type :expr)
+                        :data $ {}
+                          |D $ {} (:at 1651174678031) (:by |rJoDgvdeG) (:text |def) (:type :leaf)
+                          |T $ {} (:at 1651174671433) (:by |rJoDgvdeG) (:text |~style-name) (:type :leaf)
+                          |b $ {} (:at 1651174680848) (:by |rJoDgvdeG) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1651174685874) (:by |rJoDgvdeG) (:text |create-style!) (:type :leaf)
+                              |X $ {} (:at 1651180009735) (:by |rJoDgvdeG) (:text |~style-name-str) (:type :leaf)
+                              |b $ {} (:at 1651174691171) (:by |rJoDgvdeG) (:text |~rules) (:type :leaf)
+          |render-css-block $ {} (:at 1651175623744) (:by |rJoDgvdeG) (:type :expr)
+            :data $ {}
+              |T $ {} (:at 1651175623744) (:by |rJoDgvdeG) (:text |defn) (:type :leaf)
+              |b $ {} (:at 1651175623744) (:by |rJoDgvdeG) (:text |render-css-block) (:type :leaf)
+              |h $ {} (:at 1651175623744) (:by |rJoDgvdeG) (:type :expr)
+                :data $ {}
+                  |T $ {} (:at 1651175623744) (:by |rJoDgvdeG) (:text |style-name) (:type :leaf)
+                  |b $ {} (:at 1651175623744) (:by |rJoDgvdeG) (:text |rules) (:type :leaf)
+              |l $ {} (:at 1651175625214) (:by |rJoDgvdeG) (:type :expr)
+                :data $ {}
+                  |T $ {} (:at 1651175625214) (:by |rJoDgvdeG) (:text |->) (:type :leaf)
+                  |b $ {} (:at 1651175625214) (:by |rJoDgvdeG) (:text |rules) (:type :leaf)
+                  |h $ {} (:at 1651175625214) (:by |rJoDgvdeG) (:type :expr)
+                    :data $ {}
+                      |T $ {} (:at 1651176245931) (:by |rJoDgvdeG) (:text |.map-list) (:type :leaf)
+                      |b $ {} (:at 1651176257159) (:by |rJoDgvdeG) (:type :expr)
+                        :data $ {}
+                          |D $ {} (:at 1651176257752) (:by |rJoDgvdeG) (:text |fn) (:type :leaf)
+                          |L $ {} (:at 1651176280875) (:by |rJoDgvdeG) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1651176281453) (:by |rJoDgvdeG) (:text |pair) (:type :leaf)
+                          |T $ {} (:at 1651175625214) (:by |rJoDgvdeG) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1651176266271) (:by |rJoDgvdeG) (:text |let) (:type :leaf)
+                              |b $ {} (:at 1651176267414) (:by |rJoDgvdeG) (:type :expr)
+                                :data $ {}
+                                  |T $ {} (:at 1651175625214) (:by |rJoDgvdeG) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1651176268477) (:by |rJoDgvdeG) (:text |k) (:type :leaf)
+                                      |X $ {} (:at 1651176270158) (:by |rJoDgvdeG) (:type :expr)
+                                        :data $ {}
+                                          |T $ {} (:at 1651176271006) (:by |rJoDgvdeG) (:text |nth) (:type :leaf)
+                                          |b $ {} (:at 1651176271581) (:by |rJoDgvdeG) (:text |pair) (:type :leaf)
+                                          |h $ {} (:at 1651176272046) (:by |rJoDgvdeG) (:text |0) (:type :leaf)
+                                  |b $ {} (:at 1651175625214) (:by |rJoDgvdeG) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1651176276188) (:by |rJoDgvdeG) (:text |v) (:type :leaf)
+                                      |X $ {} (:at 1651176270158) (:by |rJoDgvdeG) (:type :expr)
+                                        :data $ {}
+                                          |T $ {} (:at 1651176271006) (:by |rJoDgvdeG) (:text |nth) (:type :leaf)
+                                          |b $ {} (:at 1651176271581) (:by |rJoDgvdeG) (:text |pair) (:type :leaf)
+                                          |h $ {} (:at 1651176278188) (:by |rJoDgvdeG) (:text |1) (:type :leaf)
+                              |h $ {} (:at 1651175625214) (:by |rJoDgvdeG) (:type :expr)
+                                :data $ {}
+                                  |T $ {} (:at 1651175625214) (:by |rJoDgvdeG) (:text |assert) (:type :leaf)
+                                  |b $ {} (:at 1651175625214) (:by |rJoDgvdeG) (:text "|\"expected rule name in string") (:type :leaf)
+                                  |h $ {} (:at 1651175625214) (:by |rJoDgvdeG) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1651175625214) (:by |rJoDgvdeG) (:text |string?) (:type :leaf)
+                                      |b $ {} (:at 1651175625214) (:by |rJoDgvdeG) (:text |k) (:type :leaf)
+                              |l $ {} (:at 1651175625214) (:by |rJoDgvdeG) (:type :expr)
+                                :data $ {}
+                                  |T $ {} (:at 1651175625214) (:by |rJoDgvdeG) (:text |assert) (:type :leaf)
+                                  |b $ {} (:at 1651175625214) (:by |rJoDgvdeG) (:text "|\"expected rule styles in map") (:type :leaf)
+                                  |h $ {} (:at 1651175625214) (:by |rJoDgvdeG) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1651175625214) (:by |rJoDgvdeG) (:text |map?) (:type :leaf)
+                                      |b $ {} (:at 1651175625214) (:by |rJoDgvdeG) (:text |v) (:type :leaf)
+                              |o $ {} (:at 1651175625214) (:by |rJoDgvdeG) (:type :expr)
+                                :data $ {}
+                                  |T $ {} (:at 1651175625214) (:by |rJoDgvdeG) (:text |let) (:type :leaf)
+                                  |b $ {} (:at 1651175625214) (:by |rJoDgvdeG) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1651175625214) (:by |rJoDgvdeG) (:type :expr)
+                                        :data $ {}
+                                          |T $ {} (:at 1651175625214) (:by |rJoDgvdeG) (:text |rule-name) (:type :leaf)
+                                          |b $ {} (:at 1651175625214) (:by |rJoDgvdeG) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1651175625214) (:by |rJoDgvdeG) (:text |.!replace) (:type :leaf)
+                                              |b $ {} (:at 1651175625214) (:by |rJoDgvdeG) (:text |k) (:type :leaf)
+                                              |h $ {} (:at 1651175625214) (:by |rJoDgvdeG) (:text "|\"$0") (:type :leaf)
+                                              |l $ {} (:at 1651175625214) (:by |rJoDgvdeG) (:text |style-name) (:type :leaf)
+                                      |b $ {} (:at 1651175625214) (:by |rJoDgvdeG) (:type :expr)
+                                        :data $ {}
+                                          |T $ {} (:at 1651175625214) (:by |rJoDgvdeG) (:text |css-line) (:type :leaf)
+                                          |b $ {} (:at 1651175625214) (:by |rJoDgvdeG) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1651175814512) (:by |rJoDgvdeG) (:text |style->string) (:type :leaf)
+                                              |b $ {} (:at 1651176091672) (:by |rJoDgvdeG) (:type :expr)
+                                                :data $ {}
+                                                  |D $ {} (:at 1651176094174) (:by |rJoDgvdeG) (:text |.to-list) (:type :leaf)
+                                                  |T $ {} (:at 1651175625214) (:by |rJoDgvdeG) (:text |v) (:type :leaf)
+                                  |h $ {} (:at 1651175625214) (:by |rJoDgvdeG) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1651175625214) (:by |rJoDgvdeG) (:text |str) (:type :leaf)
+                                      |X $ {} (:at 1651176406285) (:by |rJoDgvdeG) (:text "|\".") (:type :leaf)
+                                      |b $ {} (:at 1651175625214) (:by |rJoDgvdeG) (:text |rule-name) (:type :leaf)
+                                      |h $ {} (:at 1651175625214) (:by |rJoDgvdeG) (:text "|\" {") (:type :leaf)
+                                      |l $ {} (:at 1651175625214) (:by |rJoDgvdeG) (:text |&newline) (:type :leaf)
+                                      |o $ {} (:at 1651175625214) (:by |rJoDgvdeG) (:text |css-line) (:type :leaf)
+                                      |q $ {} (:at 1651175625214) (:by |rJoDgvdeG) (:text |&newline) (:type :leaf)
+                                      |s $ {} (:at 1651175625214) (:by |rJoDgvdeG) (:text "|\"}") (:type :leaf)
+                  |l $ {} (:at 1651175625214) (:by |rJoDgvdeG) (:type :expr)
+                    :data $ {}
+                      |T $ {} (:at 1651175625214) (:by |rJoDgvdeG) (:text |.to-list) (:type :leaf)
+                  |o $ {} (:at 1651175625214) (:by |rJoDgvdeG) (:type :expr)
+                    :data $ {}
+                      |T $ {} (:at 1651175625214) (:by |rJoDgvdeG) (:text |.join-str) (:type :leaf)
+                      |b $ {} (:at 1651175625214) (:by |rJoDgvdeG) (:type :expr)
+                        :data $ {}
+                          |T $ {} (:at 1651175625214) (:by |rJoDgvdeG) (:text |str) (:type :leaf)
+                          |b $ {} (:at 1651175625214) (:by |rJoDgvdeG) (:text |&newline) (:type :leaf)
+                          |h $ {} (:at 1651175625214) (:by |rJoDgvdeG) (:text |&newline) (:type :leaf)
+        :ns $ {} (:at 1651174518020) (:by |rJoDgvdeG) (:type :expr)
+          :data $ {}
+            |T $ {} (:at 1651174518020) (:by |rJoDgvdeG) (:text |ns) (:type :leaf)
+            |b $ {} (:at 1651174518020) (:by |rJoDgvdeG) (:text |respo.css) (:type :leaf)
+            |h $ {} (:at 1651175808277) (:by |rJoDgvdeG) (:type :expr)
+              :data $ {}
+                |T $ {} (:at 1651175809147) (:by |rJoDgvdeG) (:text |:require) (:type :leaf)
+                |b $ {} (:at 1651175809751) (:by |rJoDgvdeG) (:type :expr)
+                  :data $ {}
+                    |T $ {} (:at 1651175809751) (:by |rJoDgvdeG) (:text |respo.render.html) (:type :leaf)
+                    |b $ {} (:at 1651175809751) (:by |rJoDgvdeG) (:text |:refer) (:type :leaf)
+                    |h $ {} (:at 1651175809751) (:by |rJoDgvdeG) (:type :expr)
+                      :data $ {}
+                        |T $ {} (:at 1651175809751) (:by |rJoDgvdeG) (:text |style->string) (:type :leaf)
       |respo.cursor $ {}
         :defs $ {}
           |update-states $ {} (:at 1584871832107) (:by |rJoDgvdeG) (:type :expr)

--- a/compact.cirru
+++ b/compact.cirru
@@ -1,6 +1,6 @@
 
 {} (:package |respo)
-  :configs $ {} (:init-fn |respo.main/main!) (:reload-fn |respo.main/reload!) (:version |0.14.37)
+  :configs $ {} (:init-fn |respo.main/main!) (:reload-fn |respo.main/reload!) (:version |0.14.38)
     :modules $ [] |memof/compact.cirru |lilac/compact.cirru |calcit-test/compact.cirru
   :entries $ {}
   :files $ {}
@@ -37,28 +37,27 @@
                 div
                   {} $ :style style-task
                   comp-inspect |Task task $ {} (:left 200)
-                  button $ {}
-                    :style $ merge style-done
-                      {} $ "\"background-color"
-                        if (:done? task) (hsl 200 20 80) (hsl 200 80 70)
+                  button $ {} (:class-name style-done)
+                    :style $ {}
+                      "\"background-color" $ if (:done? task) (hsl 200 20 80) (hsl 200 80 70)
                     :on-click $ fn (e d!)
                       d! :toggle $ :id task
                   =< 8 nil
                   input $ {}
                     :value $ :text task
-                    :style widget/input
+                    :class-name widget/style-input
                     :on-input $ fn (e d!)
                       let
                           task-id $ :id task
                           text $ :value e
                         d! :update $ {} (:id task-id) (:text text)
                   =< 8 nil
-                  input $ {} (:value state) (:style widget/input)
+                  input $ {} (:value state) (:class-name widget/style-input)
                     :on-input $ fn (e d!)
                       d! cursor $ :value e
                   =< 8 nil
                   div
-                    {} (:style widget/button)
+                    {} (:class-name widget/style-button)
                       :on-click $ fn (e d!)
                         d! :remove $ :id task
                     <> |Remove
@@ -74,7 +73,8 @@
               :update (; println "\"read") nil
               :unmount (; println "\"read") nil
         |style-done $ quote
-          def style-done $ {} (:width 32) (:height 32) (:outline :none) (:border :none) (:vertical-align :middle)
+          defstyle style-done $ {}
+            "\"$0" $ {} (:width 32) (:height 32) (:outline :none) (:border :none) (:vertical-align :middle)
         |style-task $ quote
           def style-task $ {} (:display :flex) (:padding "|4px 0px")
       :ns $ quote
@@ -84,6 +84,7 @@
           respo.comp.space :refer $ =<
           respo.comp.inspect :refer $ comp-inspect
           respo.app.style.widget :as widget
+          respo.css :refer $ defstyle
     |respo.app.comp.todolist $ {}
       :defs $ {}
         |comp-todolist $ quote
@@ -99,27 +100,27 @@
                     {} $ :style style-panel
                     input $ {} (:placeholder "\"Text")
                       :value $ :draft state
-                      :style $ merge widget/input
-                        {} $ :width
-                          &max 200 $ + 24
-                            text-width (:draft state) 16 |BlinkMacSystemFont
+                      :class-name widget/style-input
+                      :style $ {}
+                        :width $ &max 200
+                          + 24 $ text-width (:draft state) 16 |BlinkMacSystemFont
                       :on-input $ fn (e d!)
                         d! cursor $ assoc state :draft (:value e)
                       :on-focus on-focus
                     =< 8 nil
                     span
-                      {} (:style widget/button)
+                      {} (:class-name widget/style-button)
                         :on-click $ fn (e d!)
                           d! :add $ :draft state
                           d! cursor $ assoc state :draft |
                       span $ {} (:on-click nil) (:inner-text "\"Add")
                     =< 8 nil
-                    span $ {} (:inner-text |Clear) (:style widget/button)
+                    span $ {} (:inner-text |Clear) (:class-name widget/style-button)
                       :on-click $ fn (e d!) (d! :clear nil)
                     =< 8 nil
                     div ({})
                       div
-                        {} (:style widget/button) (:on-click on-test)
+                        {} (:class-name widget/style-button) (:on-click on-test)
                         <> "|heavy tasks"
                   list->
                     {} (:class-name |task-list) (:style style-list)
@@ -264,17 +265,23 @@
       :defs $ {}
         |button $ quote
           def button $ {} (:display :inline-block) (:padding "\"0 6px 0 6px") (:font-family |Avenir,Verdana) (:cursor :pointer)
-            :background-color $ hsl 0 80 70
+            :background-color $ hsl 0 80 70.9
             :color $ hsl 0 0 100
             :height 28
             :line-height "\"28px"
-        |input $ quote
-          def input $ {} (:font-size |16px) (:line-height |24px) (:padding "|0px 8px") (:outline :none) (:min-width |300px)
-            :background-color $ hsl 0 0 94
-            :border :none
+            :transition-duration "\"200ms"
+        |style-button $ quote
+          defstyle style-button $ {} ("\"$0" button)
+            "\"$0:hover" $ {} (:transform "\"scale(1.04)")
+        |style-input $ quote
+          defstyle style-input $ {}
+            "\"$0" $ {} (:font-size |16px) (:line-height |24px) (:padding "|0px 8px") (:outline :none) (:min-width |300px)
+              :background-color $ hsl 0 0 94
+              :border :none
       :ns $ quote
         ns respo.app.style.widget $ :require
           respo.util.format :refer $ hsl
+          respo.css :refer $ defstyle
     |respo.app.updater $ {}
       :defs $ {}
         |updater $ quote
@@ -322,9 +329,9 @@
       :defs $ {}
         |comp-inspect $ quote
           defcomp comp-inspect (tip data style)
-            pre $ {}
+            pre $ {} (:class-name style-data)
               :inner-text $ str tip "|: " (grab-info data)
-              :style $ merge style-data style
+              :style style
               :on-click $ fn (e d!)
                 if (some? js/window.devtoolsFormatters) (js/console.log data)
                   js/console.log $ to-js-data data
@@ -344,10 +351,12 @@
               (fn? data) |Fn
               true $ pr-str data
         |style-data $ quote
-          def style-data $ {} (:position :absolute) (:background-color "\"hsl(240,100%,0%)") (:color :white) (:opacity 0.2) (:font-size |12px) (:font-family |Avenir,Verdana) (:line-height "\"1.4em") (:padding "|2px 6px") (:border-radius |4px) (:max-width 160) (:max-height 32) (:white-space :normal) (:overflow :ellipsis) (:cursor :default)
+          defstyle style-data $ {}
+            "\"$0" $ {} (:position :absolute) (:background-color "\"hsl(240,100%,0%)") (:color :white) (:opacity 0.2) (:font-size |12px) (:font-family |Avenir,Verdana) (:line-height "\"1.4em") (:padding "|2px 6px") (:border-radius |4px) (:max-width 160) (:max-height 32) (:white-space :normal) (:overflow :ellipsis) (:cursor :default)
       :ns $ quote
         ns respo.comp.inspect $ :require
           respo.core :refer $ defcomp pre <>
+          respo.css :refer $ defstyle
     |respo.comp.space $ {}
       :defs $ {}
         |=< $ quote
@@ -678,6 +687,57 @@
           respo.util.dom :refer $ compare-to-dom!
           memof.alias :refer $ tick-calling-loop! reset-calling-caches!
           memof.once :refer $ reset-memof1-caches!
+    |respo.css $ {}
+      :defs $ {}
+        |*style-caches $ quote
+          defatom *style-caches $ {}
+        |create-style! $ quote
+          defn create-style! (style-name rules)
+            assert "\"expected rules in map" $ map? rules
+            if (contains? @*style-caches style-name)
+              if
+                = rules $ get-in @*style-caches ([] style-name :rules)
+                , style-name $ let
+                    style-el $ get-in @*style-caches ([] style-name :el)
+                    css-block $ render-css-block style-name rules
+                  set! (.-innerHTML style-el) css-block
+                  swap! *style-caches assoc-in ([] style-name :rules) rules
+                  , style-name
+              let
+                  css-block $ render-css-block style-name rules
+                  style-el $ js/document.createElement "\"style"
+                set! (.-innerHTML style-el) css-block
+                set! (.-id style-el) style-name
+                js/document.head.appendChild style-el
+                swap! *style-caches assoc style-name $ {} (:rules rules) (:el style-el)
+                , style-name
+        |defstyle $ quote
+          defmacro defstyle (style-name rules)
+            assert "\"expected symbol of style-name" $ symbol? style-name
+            let
+                style-name-str $ str (turn-string style-name) "\"__"
+                  .replace
+                    turn-string $ :ns (&extract-code-into-edn style-name)
+                    , "\"." "\"_"
+              quasiquote $ def ~style-name (create-style! ~style-name-str ~rules)
+        |render-css-block $ quote
+          defn render-css-block (style-name rules)
+            -> rules
+              .map-list $ fn (pair)
+                let
+                    k $ nth pair 0
+                    v $ nth pair 1
+                  assert "\"expected rule name in string" $ string? k
+                  assert "\"expected rule styles in map" $ map? v
+                  let
+                      rule-name $ .!replace k "\"$0" style-name
+                      css-line $ style->string (.to-list v)
+                    str "\"." rule-name "\" {" &newline css-line &newline "\"}"
+              .to-list
+              .join-str $ str &newline &newline
+      :ns $ quote
+        ns respo.css $ :require
+          respo.render.html :refer $ style->string
     |respo.cursor $ {}
       :defs $ {}
         |update-states $ quote

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "version": "0.14.37",
+  "version": "0.14.38",
   "dependencies": {
-    "@calcit/procs": "^0.5.38"
+    "@calcit/procs": "^0.5.40"
   },
   "scripts": {
     "test": "cr --once --emit-js --init-fn=respo.test.main/main! && node test.mjs"

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,6 @@
+
+export default {
+  build: {
+    minify: false,
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@calcit/procs@^0.5.38":
-  version "0.5.38"
-  resolved "https://registry.yarnpkg.com/@calcit/procs/-/procs-0.5.38.tgz#7eb9ad39df784cdb5680efc312f09ab4d7baae4a"
-  integrity sha512-++4N4sqvuuVNTRD0lYOleLZgtjMyNNEie6xzXeP0N0a0Ga2JB+7+gG2o0lFI4cSkUP78vLibfDN6yOPFejU2+w==
+"@calcit/procs@^0.5.40":
+  version "0.5.40"
+  resolved "https://registry.yarnpkg.com/@calcit/procs/-/procs-0.5.40.tgz#987555f7d03943ad4928c9e6f0e01aae604be534"
+  integrity sha512-np/odIN/sh5lzwonC5+ikX0LUIOYHupVakyJyQ/Ir3z88dlLTv+NRj/Jr1IudMsfM79vQzXhoyANL2YCbSguHA==
   dependencies:
     "@calcit/ternary-tree" "0.0.19"
     "@cirru/parser.ts" "^0.0.5"


### PR DESCRIPTION
增加了一个 macro `respo.css/defstyle` 用于生成维护样式的代码, 在 `<head>...</head>` 中插入 `<style>...</style>` 来维护样式. 使用的是静态的样式, 会先于 `main!` 函数执行, 以及先于 `reload!` 执行.

<img width="662" alt="image" src="https://user-images.githubusercontent.com/449224/165848778-5fb6e192-e1f3-426d-b387-e4ab7cb120c5.png">

使用方法:

```cirru
defstyle style-input $ {}
  "\"$0" $ {} (:font-size |16px)
    :line-height |24px
    :padding "|0px 8px"
    :outline :none
    :min-width |300px
    :background-color $ hsl 0 0 94
    :border :none
```

其中 `$0` 会被替换成一个对应 className 的字符串, 如果要定义 `:hover` 的行为, 直接用 `$0:hover`.

```cirru
input $ {} (:placeholder "\"Text")
  :value $ :draft state
  :class-name widget/style-input
  :style $ {}
    :width $ &max 200
      + 24 $ text-width (:draft state) 16 |BlinkMacSystemFont
```

一些细节, 定义 `respo.app.comp.task/style-done` 生成的 className 字符串为 `style-done__respo_app_comp_task`, 通过定义的唯一性来复用, 热替换的时候判断 hashmap 的值是否改变来决定是否重新生成. 此外没有做 GC, 热替换过程生成的额外的 `<style>..</style>` 会一直残留.

依赖 Calcit 特殊的 API 才获取到 namespace 信息 https://github.com/calcit-lang/calcit/pull/172/commits/965a5a023a966537f0ab18c398a4bc27d21962a9 .