### PR TITLE
allow and mark for css rule mark

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,20 +14,20 @@ jobs:
 
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
         cache: yarn
 
     - uses: supplypike/setup-bin@v3
       with:
-        uri: 'https://github.com/calcit-lang/calcit/releases/download/0.7.0-a2/cr'
+        uri: 'https://github.com/calcit-lang/calcit/releases/download/0.7.0-a7/cr'
         name: 'cr'
-        version: '0.7.0-a2'
+        version: '0.7.0-a7'
 
     - uses: supplypike/setup-bin@v3
       with:
-        uri: 'https://github.com/calcit-lang/calcit/releases/download/0.7.0-a2/caps'
+        uri: 'https://github.com/calcit-lang/calcit/releases/download/0.7.0-a7/caps'
         name: 'caps'
-        version: '0.7.0-a2'
+        version: '0.7.0-a7'
 
     - name: "load deps"
       run: caps --ci && yarn

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -1,6 +1,6 @@
 
 {}
-  :configs $ {} (:compact-output? true) (:extension |.cljs) (:init-fn |respo.main/main!) (:output |src) (:port 6001) (:reload-fn |respo.main/reload!) (:storage-key |calcit.cirru) (:version |0.14.45)
+  :configs $ {} (:compact-output? true) (:extension |.cljs) (:init-fn |respo.main/main!) (:output |src) (:port 6001) (:reload-fn |respo.main/reload!) (:storage-key |calcit.cirru) (:version |0.14.47)
     :modules $ [] |memof/compact.cirru |lilac/compact.cirru |calcit-test/compact.cirru
   :entries $ {}
   :ir $ {} (:package |respo)
@@ -206,8 +206,8 @@
                               |T $ {} (:at 1504774121421) (:by |root) (:text |{}) (:type :leaf)
                               |j $ {} (:at 1504774121421) (:by nil) (:type :expr)
                                 :data $ {}
-                                  |T $ {} (:at 1504774121421) (:by |root) (:text |:style) (:type :leaf)
-                                  |j $ {} (:at 1504774121421) (:by |root) (:text |style-task) (:type :leaf)
+                                  |T $ {} (:at 1685804041444) (:by |rJoDgvdeG) (:text |:class-name) (:type :leaf)
+                                  |j $ {} (:at 1685804038124) (:by |rJoDgvdeG) (:text |css-task) (:type :leaf)
                           |r $ {} (:at 1504774121421) (:by nil) (:type :expr)
                             :data $ {}
                               |T $ {} (:at 1504774121421) (:by |root) (:text |comp-inspect) (:type :leaf)
@@ -431,6 +431,27 @@
                                 :data $ {}
                                   |T $ {} (:at 1504774121421) (:by |root) (:text |<>) (:type :leaf)
                                   |r $ {} (:at 1504774121421) (:by |root) (:text |state) (:type :leaf)
+          |css-task $ {} (:at 1504774121421) (:by nil) (:type :expr)
+            :data $ {}
+              |T $ {} (:at 1685804025593) (:by |rJoDgvdeG) (:text |defstyle) (:type :leaf)
+              |j $ {} (:at 1685804022546) (:by |rJoDgvdeG) (:text |css-task) (:type :leaf)
+              |r $ {} (:at 1685804026639) (:by |rJoDgvdeG) (:type :expr)
+                :data $ {}
+                  |D $ {} (:at 1685804027288) (:by |rJoDgvdeG) (:text |{}) (:type :leaf)
+                  |T $ {} (:at 1685804028443) (:by |rJoDgvdeG) (:type :expr)
+                    :data $ {}
+                      |D $ {} (:at 1685804030296) (:by |rJoDgvdeG) (:text "|\"&") (:type :leaf)
+                      |T $ {} (:at 1504774121421) (:by nil) (:type :expr)
+                        :data $ {}
+                          |T $ {} (:at 1504774121421) (:by |root) (:text |{}) (:type :leaf)
+                          |j $ {} (:at 1504774121421) (:by nil) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1504774121421) (:by |root) (:text |:display) (:type :leaf)
+                              |j $ {} (:at 1504774121421) (:by |root) (:text |:flex) (:type :leaf)
+                          |r $ {} (:at 1504774121421) (:by nil) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1504774121421) (:by |root) (:text |:padding) (:type :leaf)
+                              |j $ {} (:at 1504774121421) (:by |root) (:text "||4px 0px") (:type :leaf)
           |effect-log $ {} (:at 1571586937354) (:by |rJoDgvdeG) (:type :expr)
             :data $ {}
               |T $ {} (:at 1571586939749) (:by |rJoDgvdeG) (:text |defeffect) (:type :leaf)
@@ -527,21 +548,6 @@
                             :data $ {}
                               |T $ {} (:at 1504774121421) (:by |root) (:text |:vertical-align) (:type :leaf)
                               |j $ {} (:at 1504774121421) (:by |root) (:text |:middle) (:type :leaf)
-          |style-task $ {} (:at 1504774121421) (:by nil) (:type :expr)
-            :data $ {}
-              |T $ {} (:at 1504774121421) (:by |root) (:text |def) (:type :leaf)
-              |j $ {} (:at 1504774121421) (:by |root) (:text |style-task) (:type :leaf)
-              |r $ {} (:at 1504774121421) (:by nil) (:type :expr)
-                :data $ {}
-                  |T $ {} (:at 1504774121421) (:by |root) (:text |{}) (:type :leaf)
-                  |j $ {} (:at 1504774121421) (:by nil) (:type :expr)
-                    :data $ {}
-                      |T $ {} (:at 1504774121421) (:by |root) (:text |:display) (:type :leaf)
-                      |j $ {} (:at 1504774121421) (:by |root) (:text |:flex) (:type :leaf)
-                  |r $ {} (:at 1504774121421) (:by nil) (:type :expr)
-                    :data $ {}
-                      |T $ {} (:at 1504774121421) (:by |root) (:text |:padding) (:type :leaf)
-                      |j $ {} (:at 1504774121421) (:by |root) (:text "||4px 0px") (:type :leaf)
         :ns $ {} (:at 1504774121421) (:by nil) (:type :expr)
           :data $ {}
             |T $ {} (:at 1504774121421) (:by |root) (:text |ns) (:type :leaf)
@@ -5463,19 +5469,31 @@
                                   |T $ {} (:at 1651175625214) (:by |rJoDgvdeG) (:text |let) (:type :leaf)
                                   |b $ {} (:at 1651175625214) (:by |rJoDgvdeG) (:type :expr)
                                     :data $ {}
+                                      |D $ {} (:at 1685803941510) (:by |rJoDgvdeG) (:type :expr)
+                                        :data $ {}
+                                          |T $ {} (:at 1685803945537) (:by |rJoDgvdeG) (:text |class-rule) (:type :leaf)
+                                          |b $ {} (:at 1685803947480) (:by |rJoDgvdeG) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1685803947480) (:by |rJoDgvdeG) (:text |str) (:type :leaf)
+                                              |b $ {} (:at 1685803947480) (:by |rJoDgvdeG) (:text "|\".") (:type :leaf)
+                                              |h $ {} (:at 1685803947480) (:by |rJoDgvdeG) (:text |style-name) (:type :leaf)
                                       |T $ {} (:at 1651175625214) (:by |rJoDgvdeG) (:type :expr)
                                         :data $ {}
                                           |T $ {} (:at 1651175625214) (:by |rJoDgvdeG) (:text |rule-name) (:type :leaf)
-                                          |b $ {} (:at 1651175625214) (:by |rJoDgvdeG) (:type :expr)
+                                          |b $ {} (:at 1685803933314) (:by |rJoDgvdeG) (:type :expr)
                                             :data $ {}
-                                              |T $ {} (:at 1651175625214) (:by |rJoDgvdeG) (:text |.!replace) (:type :leaf)
-                                              |b $ {} (:at 1651175625214) (:by |rJoDgvdeG) (:text |k) (:type :leaf)
-                                              |h $ {} (:at 1651175625214) (:by |rJoDgvdeG) (:text "|\"$0") (:type :leaf)
-                                              |l $ {} (:at 1684292013419) (:by |rJoDgvdeG) (:type :expr)
+                                              |D $ {} (:at 1685803934030) (:by |rJoDgvdeG) (:text |->) (:type :leaf)
+                                              |L $ {} (:at 1685803934875) (:by |rJoDgvdeG) (:text |k) (:type :leaf)
+                                              |T $ {} (:at 1651175625214) (:by |rJoDgvdeG) (:type :expr)
                                                 :data $ {}
-                                                  |D $ {} (:at 1684292014166) (:by |rJoDgvdeG) (:text |str) (:type :leaf)
-                                                  |L $ {} (:at 1684292015948) (:by |rJoDgvdeG) (:text "|\".") (:type :leaf)
-                                                  |T $ {} (:at 1651175625214) (:by |rJoDgvdeG) (:text |style-name) (:type :leaf)
+                                                  |T $ {} (:at 1651175625214) (:by |rJoDgvdeG) (:text |.!replace) (:type :leaf)
+                                                  |h $ {} (:at 1651175625214) (:by |rJoDgvdeG) (:text "|\"$0") (:type :leaf)
+                                                  |l $ {} (:at 1685803949829) (:by |rJoDgvdeG) (:text |class-rule) (:type :leaf)
+                                              |b $ {} (:at 1651175625214) (:by |rJoDgvdeG) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1651175625214) (:by |rJoDgvdeG) (:text |.!replace) (:type :leaf)
+                                                  |h $ {} (:at 1685803955655) (:by |rJoDgvdeG) (:text "|\"&") (:type :leaf)
+                                                  |l $ {} (:at 1685803952943) (:by |rJoDgvdeG) (:text |class-rule) (:type :leaf)
                                       |b $ {} (:at 1651175625214) (:by |rJoDgvdeG) (:type :expr)
                                         :data $ {}
                                           |T $ {} (:at 1651175625214) (:by |rJoDgvdeG) (:text |css-line) (:type :leaf)

--- a/compact.cirru
+++ b/compact.cirru
@@ -1,6 +1,6 @@
 
 {} (:package |respo)
-  :configs $ {} (:init-fn |respo.main/main!) (:reload-fn |respo.main/reload!) (:version |0.14.45)
+  :configs $ {} (:init-fn |respo.main/main!) (:reload-fn |respo.main/reload!) (:version |0.14.47)
     :modules $ [] |memof/compact.cirru |lilac/compact.cirru |calcit-test/compact.cirru
   :entries $ {}
   :files $ {}
@@ -39,7 +39,7 @@
                 state $ either (:data states) |
               [] (effect-log task)
                 div
-                  {} $ :style style-task
+                  {} $ :class-name css-task
                   comp-inspect |Task task $ {} (:left 200)
                   button $ {} (:class-name style-done)
                     :style $ {}
@@ -67,6 +67,9 @@
                     <> |Remove
                   =< 8 nil
                   div ({}) (<> state)
+        |css-task $ quote
+          defstyle css-task $ {}
+            "\"&" $ {} (:display :flex) (:padding "|4px 0px")
         |effect-log $ quote
           defeffect effect-log (task) (action parent at-place?) (; js/console.log "\"Task effect" action at-place?)
             case-default action nil
@@ -79,8 +82,6 @@
         |style-done $ quote
           defstyle style-done $ {}
             "\"$0" $ {} (:width 32) (:height 32) (:outline :none) (:border :none) (:vertical-align :middle)
-        |style-task $ quote
-          def style-task $ {} (:display :flex) (:padding "|4px 0px")
       :ns $ quote
         ns respo.app.comp.task $ :require
           respo.core :refer $ defcomp div input span button <> defeffect
@@ -781,7 +782,8 @@
                   assert "\"expected rule name in string" $ string? k
                   assert "\"expected rule styles in map" $ map? v
                   let
-                      rule-name $ .!replace k "\"$0" (str "\"." style-name)
+                      class-rule $ str "\"." style-name
+                      rule-name $ -> k (.!replace "\"$0" class-rule) (.!replace "\"&" class-rule)
                       css-line $ style->string (.to-list v)
                     str rule-name "\" {" &newline css-line &newline "\"}"
               .to-list

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "version": "0.14.46",
+  "version": "0.14.47",
   "dependencies": {
-    "@calcit/procs": "^0.7.0-a2"
+    "@calcit/procs": "^0.7.0-a7"
   },
   "scripts": {
     "test": "cr --once --emit-js --init-fn=respo.test.main/main! && node test.mjs"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@calcit/procs@^0.7.0-a2":
-  version "0.7.0-a2"
-  resolved "https://registry.yarnpkg.com/@calcit/procs/-/procs-0.7.0-a2.tgz#4c3796e88ab7dce40be94003695f8f59ab3909e8"
-  integrity sha512-eP18B22NAV15dIecIGq8VL/l+zA6lC5DG8QiwHKbP/KP8+rMzLpD7ogGDKiHP0ZNH53v6wN+/l1Fvymn4pgl+Q==
+"@calcit/procs@^0.7.0-a7":
+  version "0.7.0-a7"
+  resolved "https://registry.yarnpkg.com/@calcit/procs/-/procs-0.7.0-a7.tgz#c442dc33a565836e675d6e90be7ae0c0ed5fe27a"
+  integrity sha512-OaQQWl7LYfZn1a+HtkoAvIqAGsHltV455iLiAiforGctJ0nP8+BrKm9crz0nCmVxOvlobmur7CWxoNCgEuQHeg==
   dependencies:
     "@calcit/ternary-tree" "0.0.19"
     "@cirru/parser.ts" "^0.0.6"
@@ -180,9 +180,9 @@ picocolors@^1.0.0:
   integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
 
 postcss@^8.4.23:
-  version "8.4.23"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.23.tgz#df0aee9ac7c5e53e1075c24a3613496f9e6552ab"
-  integrity sha512-bQ3qMcpF6A/YjR55xtoTr0jGOlnPOKAIMdOWiv0EIT6HVPEaJiJB4NLljSbiHoC2RX7DN5Uvjtpbg1NPdwv1oA==
+  version "8.4.24"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.24.tgz#f714dba9b2284be3cc07dbd2fc57ee4dc972d2df"
+  integrity sha512-M0RzbcI0sO/XJNucsGjvWU9ERWxb/ytp1w6dKtxTKgixdtQDq4rmx/g8W1hnaheq9jgwL/oyEdH5Bc4WwJKMqg==
   dependencies:
     nanoid "^3.3.6"
     picocolors "^1.0.0"


### PR DESCRIPTION
instead of `$0` now we can also write:

```cirru
defstyle css-a $ {}
  "& $ {}
    :color :red
```