### PR TITLE
fix: pass SSR dispatch through a ref

### DIFF
--- a/calcit.cirru
+++ b/calcit.cirru
@@ -1,6 +1,6 @@
 
 {} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `cr query` to inspect and `cr edit`/`cr tree` to modify. Run `cr docs agents --full` first. Manual edits must follow format and schema conventions, then run `cr edit format`.") (:package |respo)
-  :configs $ {} (:init-fn |respo.main/main!) (:reload-fn |respo.main/reload!) (:version |0.16.53)
+  :configs $ {} (:init-fn |respo.main/main!) (:reload-fn |respo.main/reload!) (:version |0.16.55)
     :modules $ [] |memof/ |calcit-test/
   :entries $ {}
   :files $ {}
@@ -1357,7 +1357,7 @@
                   changes $ &buf-list:new
                   collect! $ fn (op coord n-coord v)
                     &buf-list:push changes $ [] op coord n-coord v
-                  deliver-event $ build-deliver-event *global-element dispatch!
+                  deliver-event $ build-deliver-event *global-element (atom dispatch!)
                 if (nil? app-element) (raise "|Detected no element from SSR!")
                 compare-to-dom! (purify-element element) app-element
                 collect-mounting collect! ([]) ([]) element true
@@ -1777,10 +1777,9 @@
           :examples $ []
           :schema $ :: :ref
             :: :map :fn $ :: :map :any 'respo.memo/MemoEntry
-        |*memo-frame-active? $ %{} :CodeEntry (:doc |)
+        |*memo-frame-active? $ %{} :CodeEntry (:doc |) (:schema :ref)
           :code $ quote (defatom *memo-frame-active? false)
           :examples $ []
-          :schema $ :: :ref :bool
         |MemoEntry $ %{} :CodeEntry (:doc |) (:schema :dynamic)
           :code $ quote
             defstruct MemoEntry

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -1701,7 +1701,7 @@
       :defs $ {}
         |main! $ %{} :CodeEntry (:doc |)
           :code $ quote
-            defn main! () $ with-type-slot (:dispatch-op Op) (; handle-ssr! mount-target) (load-console-formatter!)
+            defn main! () $ do (; handle-ssr! mount-target) (load-console-formatter!)
               if-let
                 raw $ js/window.localStorage.getItem |respo.calcit
                 swap! *store assoc :tasks $ parse-cirru-edn raw

--- a/deps.cirru
+++ b/deps.cirru
@@ -1,4 +1,4 @@
 
-{} (:calcit-version |0.12.49)
+{} (:calcit-version |0.12.53)
   :dependencies $ {} (|calcit-lang/calcit-test |0.0.6)
-    |calcit-lang/memof |0.0.24
+    |calcit-lang/memof |0.0.26

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@calcit/procs": "^0.12.52"
+    "@calcit/procs": "^0.12.53"
   },
   "scripts": {
     "test": "cr --init-fn 'respo.test.main/main!' js && node test.mjs",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,14 +5,14 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@calcit/procs@npm:^0.12.52":
-  version: 0.12.52
-  resolution: "@calcit/procs@npm:0.12.52"
+"@calcit/procs@npm:^0.12.53":
+  version: 0.12.53
+  resolution: "@calcit/procs@npm:0.12.53"
   dependencies:
     "@calcit/ternary-tree": "npm:0.0.26"
     "@cirru/parser.ts": "npm:^0.0.9"
     "@cirru/writer.ts": "npm:^0.1.9"
-  checksum: 10c0/fd44fdbc7873031b9b53aea58236c614540ca7cd00d5eff0520349e8b02dbefa33cff1f9713caaff06439e36b57113613610582c46a52693b6752b0fafd5f788
+  checksum: 10c0/d6f1d94bb582789a761c007d8f6d654975ef1748229fe81c41a2f51e371188ef7b2660109830360883ca2d16dec83a63db8cfdf5bce9390ae336d5e9554846b7
   languageName: node
   linkType: hard
 
@@ -984,7 +984,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    "@calcit/procs": "npm:^0.12.52"
+    "@calcit/procs": "npm:^0.12.53"
     bottom-tip: "npm:^0.1.5"
     vite: "npm:^8.0.3"
   languageName: unknown


### PR DESCRIPTION
修复 SSR 路径中 dispatch 参数类型不一致：realize-ssr! 接收普通函数，但 build-deliver-event 需要 Ref。现在通过 atom 包装后传入。

验证：cr js、respo.test.main/main! js、node test.mjs 均通过。