### PR TITLE
feat: add typed dispatch config and normalize VDOM behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,6 @@ draft/
 .yarn/*.gz
 
 .calcit-snippets/
+.calcit/
 
 .DS_Store

--- a/Agents.md
+++ b/Agents.md
@@ -28,10 +28,7 @@ Typed dispatch / type slot:
 
 - 对 README/文档中的 Cirru 代码块，使用 `check-md` 并显式加载当前项目 `calcit.cirru` 作为依赖:
   - `cr calcit.cirru docs check-md README.md --dep ./`
-- 若 README 代码块用到 `respo.core/clear-cache!`（依赖 `memof.once`），校验时额外添加 `memof` 依赖:
-  - `cr calcit.cirru docs check-md README.md --dep ./ --dep ~/.config/calcit/modules/memof/`
 - `--dep ./` 会按目录加载 `./calcit.cirru`，用于在代码块中访问 `respo.core` 等命名空间函数。
-- `--dep ~/.config/calcit/modules/memof/` 会按目录加载 `memof/compact.cirru`，避免 `memof.once/*` 相关解析失败。
 - 若代码块是“示意片段”而非可独立运行程序，优先标记为 `cirru.no-check`。
 - 若需要在单个代码块里串联多个表达式并共享中间值，使用 `let` 显式绑定；默认不会把前面表达式自动注册为全局定义。
 

--- a/Agents.md
+++ b/Agents.md
@@ -16,6 +16,12 @@ cr docs agents --full
 - 仅在确有必要时使用 `hint-fn`，并优先采用 schema map 形式；避免旧 clause 写法。
 - 修改签名后，优先用 `cr js` 验证，确保不会因类型告警阻断编译。
 
+Typed dispatch / type slot:
+
+- Respo 通过 `respo.schema/*dispatch-op` 为事件回调传递应用级 `Op` 类型。应用应使用 `cr config set-type-slot :dispatch-op app.schema/Op` 为每个 entry 单独绑定，不要在 `main!` 中写 `bind-type` 或依赖 `with-type-slot` wrapper。
+- 修改 `d! $ :: ...`、事件 handler schema 或 entry 配置前，优先复用模块指南：`cr docs search 'typed dispatch' --module respo.calcit`，再运行 `cr docs read type-slots.md --full --module respo.calcit`。
+- 命名 entry 不继承默认 `:configs.type-slots`；用 `cr config type-slots [--entry name]` 确认实际绑定，并以同一个 `--entry` 运行 `--check-only` / `js`。
+
 然后 GPT 调用 `cr` 命令增量编辑源码, 在 `cr edit inc` 运行时触发重新编译.
 
 文档示例校验建议:

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ In `package.cirru` and run `caps`:
 
 DOM syntax
 
-```cirru.no-run
+```cirru.no-check
 ; ns app.demo $ :require
   respo.core :refer $ div
 
@@ -233,6 +233,7 @@ This index helps LLM tools automatically fetch and reference documentation using
 | Component States | [docs/guide/component-states.md](docs/guide/component-states.md) | Managing component state           |
 | DOM Properties   | [docs/guide/dom-properties.md](docs/guide/dom-properties.md)     | DOM property binding               |
 | DOM Events       | [docs/guide/dom-events.md](docs/guide/dom-events.md)             | Event handling in Respo            |
+| Typed Dispatch   | [docs/guide/type-slots.md](docs/guide/type-slots.md)             | Entry-level `Op` binding and checks |
 | Styles           | [docs/guide/styles.md](docs/guide/styles.md)                     | CSS and styling approach           |
 | Render Lists     | [docs/guide/render-list.md](docs/guide/render-list.md)           | Efficient list rendering           |
 | Hot Swapping     | [docs/guide/hot-swapping.md](docs/guide/hot-swapping.md)         | Hot code reloading setup           |

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 - **Init Function**: `respo.main/main!`
 - **Reload Function**: `respo.main/reload!`
 - **Core Namespaces**: 33 namespaces providing virtual DOM, rendering, components, and utilities
-- **Dependencies**: memof, lilac, calcit-test modules
+- **Dependencies**: calcit-test module
 
 ### Usage
 
@@ -152,7 +152,10 @@ list->
 
 `memo-comp-by` matches the component function, key, and complete argument list. Each
 `render-with!` call records active keys and prunes entries that disappeared from the
-latest tree. Passing `nil` as the key bypasses caching.
+latest tree. Passing `nil` as the key bypasses caching. Respo manages this cache
+internally, so applications do not need `memof` for component memoization. See
+[Render list: memoization and memof migration](docs/guide/render-list.md#memoizing-components)
+for setup, lifecycle, and migration details.
 
 Reset virtual DOM caching during hot code swapping, and rerender:
 

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -1,6 +1,6 @@
 
 {} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `cr query` to inspect and `cr edit`/`cr tree` to modify. Run `cr docs agents --full` first. Manual edits must follow format and schema conventions, then run `cr edit format`.") (:package |respo)
-  :configs $ {} (:init-fn |respo.main/main!) (:reload-fn |respo.main/reload!) (:version |0.16.57)
+  :configs $ {} (:init-fn |respo.main/main!) (:reload-fn |respo.main/reload!) (:version |0.16.58)
     :modules $ [] |memof/ |calcit-test/
     :type-slots $ {} (:dispatch-op |respo.app.schema/Op)
   :entries $ {}

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -1,6 +1,6 @@
 
 {} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `cr query` to inspect and `cr edit`/`cr tree` to modify. Run `cr docs agents --full` first. Manual edits must follow format and schema conventions, then run `cr edit format`.") (:package |respo)
-  :configs $ {} (:init-fn |respo.main/main!) (:reload-fn |respo.main/reload!) (:version |0.16.56)
+  :configs $ {} (:init-fn |respo.main/main!) (:reload-fn |respo.main/reload!) (:version |0.16.57)
     :modules $ [] |memof/ |calcit-test/
   :entries $ {}
   :files $ {}

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -1,9 +1,9 @@
 
-{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `cr query` to inspect and `cr edit`/`cr tree` to modify. Run `cr docs agents --full` first. Manual edits must follow format and schema conventions, then run `cr edit format`.") (:package |respo)
-  :configs $ {} (:init-fn |respo.main/main!) (:reload-fn |respo.main/reload!) (:version |0.16.58)
-    :modules $ [] |memof/ |calcit-test/
-    :type-slots $ {} (:dispatch-op |respo.app.schema/Op)
+{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `cr query` to inspect and `cr edit`/`cr tree` to modify. Run `cr docs agents --full` first. Manual edits must follow format and schema conventions, then run `cr edit format`.") (:package |respo) (:version |0.16.58)
   :entries $ {}
+    :default $ {} (:description |) (:init-fn 'respo.main/main!) (:mode :js) (:reload-fn 'respo.main/reload!)
+      :modules $ [] |memof/ |calcit-test/
+      :type-slots $ {} (:dispatch-op |respo.app.schema/Op)
   :files $ {}
     |respo.app.comp.container $ %{} :FileEntry
       :defs $ {}

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -1,5 +1,5 @@
 
-{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `cr query` to inspect and `cr edit`/`cr tree` to modify. Run `cr docs agents --full` first. Manual edits must follow format and schema conventions, then run `cr edit format`.") (:package |respo) (:version |0.16.58)
+{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `cr query` to inspect and `cr edit`/`cr tree` to modify. Run `cr docs agents --full` first. Manual edits must follow format and schema conventions, then run `cr edit format`.") (:package |respo) (:version |0.16.59)
   :entries $ {}
     :default $ {} (:description |) (:init-fn 'respo.main/main!) (:mode :js) (:reload-fn 'respo.main/reload!)
       :modules $ [] |calcit-test/

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -2,7 +2,7 @@
 {} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `cr query` to inspect and `cr edit`/`cr tree` to modify. Run `cr docs agents --full` first. Manual edits must follow format and schema conventions, then run `cr edit format`.") (:package |respo) (:version |0.16.58)
   :entries $ {}
     :default $ {} (:description |) (:init-fn 'respo.main/main!) (:mode :js) (:reload-fn 'respo.main/reload!)
-      :modules $ [] |memof/ |calcit-test/
+      :modules $ [] |calcit-test/
       :type-slots $ {} (:dispatch-op |respo.app.schema/Op)
   :files $ {}
     |respo.app.comp.container $ %{} :FileEntry
@@ -953,7 +953,7 @@
               :args $ [] (:: :optional 'respo.schema/DomProps)
         |clear-cache! $ %{} :CodeEntry (:doc "|Clear memoized render caches used by Respo.\n\nThis is mainly useful during hot reloading or code swapping, where mounted DOM may stay in place but cached render results must be dropped before the next render.")
           :code $ quote
-            defn clear-cache! () (memo/reset-component-caches!) (reset-memof1-caches!)
+            defn clear-cache! () $ memo/reset-component-caches!
           :examples $ []
           :schema $ :: :fn
             {} (:return :unit)
@@ -1493,7 +1493,6 @@
             respo.util.list :refer $ pick-attrs pick-event val-exists?
             respo.schema :as schema
             respo.util.dom :refer $ compare-to-dom!
-            memof.once :refer $ reset-memof1-caches!
             respo.util.detect :refer $ component? element? effect? listener?
             respo.memo :as memo
     |respo.css $ %{} :FileEntry

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -2,6 +2,7 @@
 {} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `cr query` to inspect and `cr edit`/`cr tree` to modify. Run `cr docs agents --full` first. Manual edits must follow format and schema conventions, then run `cr edit format`.") (:package |respo)
   :configs $ {} (:init-fn |respo.main/main!) (:reload-fn |respo.main/reload!) (:version |0.16.57)
     :modules $ [] |memof/ |calcit-test/
+    :type-slots $ {} (:dispatch-op |respo.app.schema/Op)
   :entries $ {}
   :files $ {}
     |respo.app.comp.container $ %{} :FileEntry

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -1276,8 +1276,8 @@
                   :tree $ <> label
               , |demo
           :schema $ :: :fn
-            {} (:rest :any) (:return 'respo.schema/Component)
-              :args $ [] :any :fn
+            {} (:rest :dynamic) (:return 'respo.schema/Component)
+              :args $ [] :dynamic :fn
         |mount-app! $ %{} :CodeEntry (:doc "|Mounts the Respo application to the DOM. Initializes the global element and event listeners.")
           :code $ quote
             defn mount-app! (target element *dispatch-fn)
@@ -1688,13 +1688,14 @@
                 fn (s)
                   if (nil? s)
                     noted "|merge base initial state" $ merge state0 changes
-                    if (map? s)
+                    if
+                      or (map? s) (record? s)
                       noted "|merge base latest state" $ merge s changes
                       do (js/console.warn "|unknown data to merge:" s) s
           :examples $ []
           :schema $ :: :fn
             {} (:return :map)
-              :args $ [] :map :list :map :map
+              :args $ [] :map :list :dynamic :map
       :ns $ %{} :NsEntry (:doc |)
         :code $ quote (ns respo.cursor)
     |respo.main $ %{} :FileEntry
@@ -1770,13 +1771,13 @@
             defatom *component-caches $ {}
           :examples $ []
           :schema $ :: :ref
-            :: :map :fn $ :: :map :any 'respo.memo/MemoEntry
+            :: :map :fn $ :: :map :dynamic 'respo.memo/MemoEntry
         |*frame-component-caches $ %{} :CodeEntry (:doc |)
           :code $ quote
             defatom *frame-component-caches $ {}
           :examples $ []
           :schema $ :: :ref
-            :: :map :fn $ :: :map :any 'respo.memo/MemoEntry
+            :: :map :fn $ :: :map :dynamic 'respo.memo/MemoEntry
         |*memo-frame-active? $ %{} :CodeEntry (:doc |) (:schema :ref)
           :code $ quote (defatom *memo-frame-active? false)
           :examples $ []
@@ -1805,7 +1806,7 @@
           :examples $ []
           :schema $ :: :fn
             {} (:return 'respo.schema/Component)
-              :args $ [] :fn (:: :list :any)
+              :args $ [] :fn :list
         |component-cache-size $ %{} :CodeEntry (:doc |)
           :code $ quote
             defn component-cache-size () $ reduce (&map:to-list @*component-caches) 0
@@ -1845,8 +1846,8 @@
                   :value resolved-entry
           :examples $ []
           :schema $ :: :fn
-            {} (:rest :any) (:return 'respo.schema/Component)
-              :args $ [] :any :fn
+            {} (:rest :dynamic) (:return 'respo.schema/Component)
+              :args $ [] :dynamic :fn
         |reset-component-caches! $ %{} :CodeEntry (:doc |)
           :code $ quote
             defn reset-component-caches! ()
@@ -1892,92 +1893,101 @@
         |find-children-diffs $ %{} :CodeEntry (:doc "|Compares lists of child elements to find structural differences.")
           :code $ quote
             defn find-children-diffs (collect! coord n-coord index old-children new-children) (; js/console.log "|diff children:" n-coord index old-children new-children)
-              let
-                  was-empty? $ empty? old-children
-                  now-empty? $ empty? new-children
-                cond
-                    and was-empty? now-empty?
-                    , nil
-                  (and was-empty? (not now-empty?))
-                    let
-                        pair $ first new-children
-                        k $ first pair
-                        element $ last pair
-                        new-coord $ conj coord k
-                      collect! $ :: :append-element new-coord n-coord element
-                      collect-mounting collect! coord (conj n-coord index) element true
-                      recur collect! coord n-coord (inc index) ([]) (rest new-children)
-                  (and (not was-empty?) now-empty?)
-                    let
-                        pair $ first old-children
-                        k $ first pair
-                        new-coord $ conj coord k
-                        new-n-coord $ conj n-coord index
-                      collect-unmounting collect! coord new-n-coord (last pair) true
-                      collect! $ :: :rm-element new-coord new-n-coord nil
-                      recur collect! coord n-coord index (rest old-children) ([])
-                  true $ let
-                      old-keys $ -> old-children (take 16) (map first)
-                      new-keys $ -> new-children (take 16) (map first)
-                      x1 $ first old-keys
-                      y1 $ first new-keys
-                      match-x1 $ fn (x) (= x x1)
-                      match-y1 $ fn (x) (= x y1)
-                      x1-remains? $ any? new-keys match-x1
-                      y1-existed? $ any? old-keys match-y1
-                      old-follows $ rest old-children
-                      new-follows $ rest new-children
-                    if (nil? y1) (js/console.warn "|nil key is bad in Respo")
-                    ; println |compare: x1 new-keys x1-remains? y1 y1-existed? old-keys
-                    cond
-                        &= x1 y1
-                        let
-                            old-element $ val-of-first old-children
-                            new-element $ val-of-first new-children
-                          find-element-diffs collect! (conj coord x1) (conj n-coord index) old-element new-element
-                          recur collect! coord n-coord (inc index) old-follows new-follows
-                      (and x1-remains? (not y1-existed?))
-                        let
-                            pair $ first new-children
-                            k $ first pair
-                            element $ last pair
-                            new-coord $ conj coord k
-                            new-n-coord $ conj n-coord index
-                          collect! $ :: :add-element new-coord new-n-coord element
-                          collect-mounting collect! coord new-n-coord (val-of-first new-children) true
-                          recur collect! coord n-coord (inc index) old-children new-follows
-                      (and (not x1-remains?) y1-existed?)
-                        let
-                            pair $ first old-children
-                            k $ first pair
-                            new-coord $ conj coord k
-                            new-n-coord $ conj n-coord index
-                          collect-unmounting collect! coord new-n-coord (last pair) true
-                          collect! $ :: :rm-element new-coord new-n-coord nil
-                          recur collect! coord n-coord index old-follows new-children
-                      true $ let
-                          xi $ index-of new-keys x1
-                          yi $ index-of old-keys y1
-                          first-old-entry $ first old-children
-                          first-new-entry $ first new-children
+              if
+                or (map? old-children) (map? new-children)
+                recur collect! coord n-coord index
+                  if (map? old-children)
+                    -> (.to-list old-children) .to-list
+                    , old-children
+                  if (map? new-children)
+                    -> (.to-list new-children) .to-list
+                    , new-children
+                let
+                    was-empty? $ empty? old-children
+                    now-empty? $ empty? new-children
+                  cond
+                      and was-empty? now-empty?
+                      , nil
+                    (and was-empty? (not now-empty?))
+                      let
+                          pair $ first new-children
+                          k $ first pair
+                          element $ last pair
+                          new-coord $ conj coord k
+                        collect! $ :: :append-element new-coord n-coord element
+                        collect-mounting collect! coord (conj n-coord index) element true
+                        recur collect! coord n-coord (inc index) ([]) (rest new-children)
+                    (and (not was-empty?) now-empty?)
+                      let
+                          pair $ first old-children
+                          k $ first pair
+                          new-coord $ conj coord k
                           new-n-coord $ conj n-coord index
-                        ; println |index: xi yi
-                        if
-                          not $ &= 1 (&compare xi yi)
+                        collect-unmounting collect! coord new-n-coord (last pair) true
+                        collect! $ :: :rm-element new-coord new-n-coord nil
+                        recur collect! coord n-coord index (rest old-children) ([])
+                    true $ let
+                        old-keys $ -> old-children (take 16) (map first)
+                        new-keys $ -> new-children (take 16) (map first)
+                        x1 $ first old-keys
+                        y1 $ first new-keys
+                        match-x1 $ fn (x) (= x x1)
+                        match-y1 $ fn (x) (= x y1)
+                        x1-remains? $ any? new-keys match-x1
+                        y1-existed? $ any? old-keys match-y1
+                        old-follows $ rest old-children
+                        new-follows $ rest new-children
+                      if (nil? y1) (js/console.warn "|nil key is bad in Respo")
+                      ; println |compare: x1 new-keys x1-remains? y1 y1-existed? old-keys
+                      cond
+                          &= x1 y1
                           let
+                              old-element $ val-of-first old-children
                               new-element $ val-of-first new-children
-                              new-coord $ conj coord y1
-                            collect! $ :: :add-element new-coord new-n-coord new-element
-                            collect-mounting collect! coord new-n-coord new-element true
+                            find-element-diffs collect! (conj coord x1) (conj n-coord index) old-element new-element
+                            recur collect! coord n-coord (inc index) old-follows new-follows
+                        (and x1-remains? (not y1-existed?))
+                          let
+                              pair $ first new-children
+                              k $ first pair
+                              element $ last pair
+                              new-coord $ conj coord k
+                              new-n-coord $ conj n-coord index
+                            collect! $ :: :add-element new-coord new-n-coord element
+                            collect-mounting collect! coord new-n-coord (val-of-first new-children) true
                             recur collect! coord n-coord (inc index) old-children new-follows
-                          do
-                            collect-unmounting collect! coord new-n-coord (val-of-first old-children) true
-                            collect! $ :: :rm-element (conj coord x1) new-n-coord nil
+                        (and (not x1-remains?) y1-existed?)
+                          let
+                              pair $ first old-children
+                              k $ first pair
+                              new-coord $ conj coord k
+                              new-n-coord $ conj n-coord index
+                            collect-unmounting collect! coord new-n-coord (last pair) true
+                            collect! $ :: :rm-element new-coord new-n-coord nil
                             recur collect! coord n-coord index old-follows new-children
+                        true $ let
+                            xi $ index-of new-keys x1
+                            yi $ index-of old-keys y1
+                            first-old-entry $ first old-children
+                            first-new-entry $ first new-children
+                            new-n-coord $ conj n-coord index
+                          ; println |index: xi yi
+                          if
+                            not $ &= 1 (&compare xi yi)
+                            let
+                                new-element $ val-of-first new-children
+                                new-coord $ conj coord y1
+                              collect! $ :: :add-element new-coord new-n-coord new-element
+                              collect-mounting collect! coord new-n-coord new-element true
+                              recur collect! coord n-coord (inc index) old-children new-follows
+                            do
+                              collect-unmounting collect! coord new-n-coord (val-of-first old-children) true
+                              collect! $ :: :rm-element (conj coord x1) new-n-coord nil
+                              recur collect! coord n-coord index old-follows new-children
           :examples $ []
           :schema $ :: :fn
             {} (:return :unit)
-              :args $ [] :fn :list :list :number :list :list
+              :args $ [] :fn :list :list :number :dynamic :dynamic
         |find-element-diffs $ %{} :CodeEntry (:doc "|Internal diff algorithm for comparing old and new virtual DOM trees.\n\nIt collects patch operations via `collect!`, handling components, plain elements, styles, events, keyed children, and effect lifecycle transitions.")
           :code $ quote
             defn find-element-diffs (collect! coord n-coord old-tree new-tree) (; js/console.log "|element diffing:" n-coord old-tree new-tree) (; echo "|element coord" coord)
@@ -2048,46 +2058,51 @@
           :code $ quote
             defn find-props-diffs (collect! coord n-coord old-props new-props)
               ; js/console.log "|find props:" n-coord old-props new-props (count old-props) (count new-props)
-              let
-                  was-empty? $ empty? old-props
-                  now-empty? $ empty? new-props
-                cond
-                    and was-empty? now-empty?
-                    , nil
-                  (and was-empty? (not now-empty?))
-                    do
-                      collect! $ :: :add-prop coord n-coord (first new-props)
-                      recur collect! coord n-coord old-props $ rest new-props
-                  (and (not was-empty?) now-empty?)
-                    do
-                      collect! $ :: :rm-prop coord n-coord
-                        first $ first old-props
-                      recur collect! coord n-coord (rest old-props) new-props
-                  true $ let
-                      old-pair $ first old-props
-                      new-pair $ first new-props
-                      old-k $ first old-pair
-                      old-v $ last old-pair
-                      new-k $ first new-pair
-                      new-v $ last new-pair
-                      old-follows $ rest old-props
-                      new-follows $ rest new-props
-                    ; js/console.log old-k new-k old-v new-v
-                    case-default (&compare old-k new-k) (eprintln "|[Respo] unknown compare result for props keys")
-                      -1 $ do
-                        collect! $ :: :rm-prop coord n-coord old-k
-                        recur collect! coord n-coord old-follows new-props
-                      1 $ do
-                        collect! $ :: :add-prop coord n-coord new-pair
-                        recur collect! coord n-coord old-props new-follows
-                      0 $ do
-                        if (not= old-v new-v)
-                          collect! $ :: :replace-prop coord n-coord new-pair
-                        recur collect! coord n-coord old-follows new-follows
+              if
+                and (list? old-props) (list? new-props)
+                let
+                    was-empty? $ empty? old-props
+                    now-empty? $ empty? new-props
+                  cond
+                      and was-empty? now-empty?
+                      , nil
+                    (and was-empty? (not now-empty?))
+                      do
+                        collect! $ :: :add-prop coord n-coord (first new-props)
+                        recur collect! coord n-coord old-props $ rest new-props
+                    (and (not was-empty?) now-empty?)
+                      do
+                        collect! $ :: :rm-prop coord n-coord
+                          first $ first old-props
+                        recur collect! coord n-coord (rest old-props) new-props
+                    true $ let
+                        old-pair $ first old-props
+                        new-pair $ first new-props
+                        old-k $ first old-pair
+                        old-v $ last old-pair
+                        new-k $ first new-pair
+                        new-v $ last new-pair
+                        old-follows $ rest old-props
+                        new-follows $ rest new-props
+                      ; js/console.log old-k new-k old-v new-v
+                      case-default (&compare old-k new-k) (eprintln "|[Respo] unknown compare result for props keys")
+                        -1 $ do
+                          collect! $ :: :rm-prop coord n-coord old-k
+                          recur collect! coord n-coord old-follows new-props
+                        1 $ do
+                          collect! $ :: :add-prop coord n-coord new-pair
+                          recur collect! coord n-coord old-props new-follows
+                        0 $ do
+                          if (not= old-v new-v)
+                            collect! $ :: :replace-prop coord n-coord new-pair
+                          recur collect! coord n-coord old-follows new-follows
+                recur collect! coord n-coord
+                  if (list? old-props) old-props $ -> old-props .to-list
+                  if (list? new-props) new-props $ -> new-props .to-list
           :examples $ []
           :schema $ :: :fn
             {} (:return :unit)
-              :args $ [] :fn :list :list :list :list
+              :args $ [] :fn :list :list :dynamic :dynamic
         |find-style-diffs $ %{} :CodeEntry (:doc "|Compares two style maps and collects effects for additions, removals, or updates.")
           :code $ quote
             defn find-style-diffs (collect! c-coord coord old-style new-style)
@@ -2155,8 +2170,16 @@
                     events $ &record:get virtual-element :event
                     children $ &record:get virtual-element :children
                     element $ js/document.createElement tag-name
-                    child-elements $ -> children
-                      map $ fn (pair)
+                    child-elements $ if (map? children)
+                      map (.to-list children)
+                        fn (pair)
+                          assert "|expect pair of key/element" $ and (list? pair)
+                            &= 2 $ count pair
+                          let[] (k child) pair
+                            when (nil? k) (js/console.warn "|nil key is bad for Respo")
+                            when (some? child)
+                              make-element child listener-builder $ conj coord k
+                      map children $ fn (pair)
                         assert "|expect pair of key/element" $ and (list? pair)
                           &= 2 $ count pair
                         let[] (k child) pair
@@ -2168,7 +2191,9 @@
                         prop-str $ turn-string (first entry)
                         v $ last entry
                       if (.!startsWith prop-str |data-)
-                        -> element .-dataset $ js-set (.!slice prop-str 5) v
+                        if (some? v)
+                          -> element .-dataset $ js-set (.!slice prop-str 5) v
+                          -> element .-dataset $ js-delete (.!slice prop-str 5)
                         let
                             k $ dashed->camel prop-str
                           if (some? v) (aset element k v)
@@ -2240,7 +2265,12 @@
                     recur collect! next-coord n-coord (:tree tree) false
                 (element? tree)
                   loop
-                      children $ :children tree
+                      children $ if
+                        map? $ :children tree
+                        ->
+                          .to-list $ :children tree
+                          , .to-list
+                        :children tree
                       idx 0
                     when
                       not $ empty? children
@@ -2273,7 +2303,12 @@
                               method (:args effect) ([] :unmount target at-place?)
                 (element? tree)
                   loop
-                      children $ :children tree
+                      children $ if
+                        map? $ :children tree
+                        ->
+                          .to-list $ :children tree
+                          , .to-list
+                        :children tree
                       idx 0
                     when
                       not $ empty? children
@@ -2467,7 +2502,9 @@
               let
                   prop-str $ turn-string p
                 if (.!startsWith prop-str |data-)
-                  -> target .-dataset $ js-set (.!slice prop-str 5) prop-value
+                  if (some? prop-value)
+                    -> target .-dataset $ js-set (.!slice prop-str 5) prop-value
+                    -> target .-dataset $ js-delete (.!slice prop-str 5)
                   let
                       prop-name $ dashed->camel prop-str
                     case-default prop-name (js-set target prop-name prop-value)
@@ -2567,9 +2604,11 @@
                 if (.!startsWith prop-str |data-)
                   let
                       name $ .!slice prop-str 5
-                    if
-                      not= prop-value $ -> target .-dataset (aget name)
-                      -> target .-dataset $ js-set name prop-value
+                    if (some? prop-value)
+                      if
+                        not= prop-value $ -> target .-dataset (aget name)
+                        -> target .-dataset $ js-set name prop-value
+                      -> target .-dataset $ js-delete name
                   let
                       prop-name $ dashed->camel prop-str
                     if (identical? prop-name |value)
@@ -2920,7 +2959,7 @@
       :defs $ {}
         |main! $ %{} :CodeEntry (:doc |)
           :code $ quote
-            defn main! () (html/run-tests) (test-pick-attrs) (test-pick-event) (memo/run-tests) (test-find-props-diffs)
+            defn main! () (html/run-tests) (test-pick-attrs) (test-pick-event) (memo/run-tests) (test-find-props-diffs) (test-pair-representation-transitions) (test-update-states-merge-record)
           :examples $ []
           :schema $ :: :fn
             {} (:return :unit)
@@ -2945,13 +2984,33 @@
                 is $ = (first @effects)
                   :: :replace-prop ([]) ([]) ([] :class-name |new)
           :examples $ []
+        |test-pair-representation-transitions $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+          :code $ quote
+            deftest test-pair-representation-transitions $ testing |pair_collections_support_list_and_map_transitions
+              let
+                  child $ div ({})
+                  *ops $ atom ([])
+                  collect! $ fn (op) (swap! *ops conj op)
+                  child-list $ [] ([] :a child)
+                  child-map $ {} (:a child)
+                  prop-list $ [] ([] :title |same)
+                  prop-map $ {} (:title |same)
+                find-children-diffs collect! ([]) ([]) 0 child-list child-map
+                find-children-diffs collect! ([]) ([]) 0 child-map child-list
+                find-props-diffs collect! ([]) ([]) prop-list prop-map
+                find-props-diffs collect! ([]) ([]) prop-map prop-list
+                is $ empty? @*ops
+          :examples $ []
         |test-pick-attrs $ %{} :CodeEntry (:doc |) (:schema :dynamic)
           :code $ quote
-            deftest test-pick-attrs $ is
-              =
+            deftest test-pick-attrs
+              is $ =
                 pick-attrs $ {} (:value |string)
                   :on-click $ fn () nil
                 [] $ [] :value |string
+              is $ =
+                pick-attrs $ {} (:data-comp nil) (:data-name nil) (:title |ok)
+                [] $ [] :title |ok
           :examples $ []
         |test-pick-event $ %{} :CodeEntry (:doc |) (:schema :dynamic)
           :code $ quote
@@ -2966,13 +3025,29 @@
                     :on $ {} (:input f)
                   {} (:click f) (:input f)
           :examples $ []
+        |test-update-states-merge-record $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+          :code $ quote
+            deftest test-update-states-merge-record $ testing |record_state_supports_repeated_merges
+              let
+                  state0 $ %{} TodoState (:draft |a) (:locked? false) (:message |ready)
+                  store1 $ update-states-merge ({}) ([]) state0
+                    {} $ :draft |b
+                  store2 $ update-states-merge store1 ([]) state0
+                    {} $ :draft |c
+                  state2 $ get-in store2 ([] :states :data)
+                is $ record? state2
+                is $ = |c (:draft state2)
+          :examples $ []
       :ns $ %{} :NsEntry (:doc |)
         :code $ quote
           ns respo.test.main $ :require (respo.test.html :as html)
             calcit-test.core :refer $ deftest testing is
             respo.util.list :refer $ pick-attrs pick-event
             respo.test.memo :as memo
-            respo.render.diff :refer $ find-props-diffs
+            respo.render.diff :refer $ find-children-diffs find-props-diffs
+            respo.cursor :refer $ update-states-merge
+            respo.core :refer $ div
+            respo.app.schema :refer $ TodoState
     |respo.test.memo $ %{} :FileEntry
       :defs $ {}
         |*render-count $ %{} :CodeEntry (:doc |) (:schema :ref)
@@ -3403,7 +3478,8 @@
                     let
                         k $ nth pair 0
                         v $ nth pair 1
-                      not $ starts-with? (turn-string k) |on-
+                      and (some? v)
+                        not $ starts-with? (turn-string k) |on-
                   sort $ fn (x y)
                     &compare (nth x 0) (nth y 0)
           :examples $ []

--- a/deps.cirru
+++ b/deps.cirru
@@ -1,4 +1,4 @@
 
-{} (:calcit-version |0.12.53)
+{} (:calcit-version |0.12.54)
   :dependencies $ {} (|calcit-lang/calcit-test |0.0.6)
     |calcit-lang/memof |0.0.26

--- a/deps.cirru
+++ b/deps.cirru
@@ -1,4 +1,4 @@
 
-{} (:calcit-version |0.12.54)
+{} (:calcit-version |0.12.55)
   :dependencies $ {} (|calcit-lang/calcit-test |0.0.6)
     |calcit-lang/memof |0.0.26

--- a/deps.cirru
+++ b/deps.cirru
@@ -1,4 +1,3 @@
 
 {} (:calcit-version |0.12.55)
   :dependencies $ {} (|calcit-lang/calcit-test |0.0.6)
-    |calcit-lang/memof |0.0.26

--- a/docs/Respo-Agent.md
+++ b/docs/Respo-Agent.md
@@ -445,85 +445,32 @@ js/window.setTimeout
 
 ### 7. Type Slot — Typed Dispatch with Enum Validation
 
-**Type slots** allow the compiler to know the concrete type of `dispatch!` (typically the app-level `Op` enum) inside event handler closures. This enables:
+**Type slots** let the application choose the concrete `Op` enum accepted by Respo's `dispatch!` callbacks without passing a generic through every component API. The canonical, reusable guide is [Typed dispatch with type slots](./guide/type-slots.md); when Respo is installed, reopen it with:
 
-- **Auto-rewrite**: `:: :variant` shorthand automatically rewrites to `%:: Op :variant` at compile time.
-- **Variant validation**: invalid variants like `:: :typo` produce a compile-time warning (codegen blocked).
-- **Type checking**: the `d!` parameter inside `fn (e d!)` gets a typed signature.
-
-#### Setup in `main!`
-
-Declare the type slot once at the application entry point, binding it to your `Op` enum:
-
-```cirru.no-check
-; respo.main/main!
-defn main! ()
-  bind-type :dispatch-op respo.app.schema/Op
-  render-app! mount-point
+```bash
+cr docs search 'typed dispatch' --module respo.calcit
+cr docs read type-slots.md --full --module respo.calcit
 ```
 
-`bind-type` does not require a prior `deftype-slot` call — it auto-registers the slot on first use. Using it a second time with the same slot name is an error.
+Bind the slot in the configuration for every entry that builds Respo components:
 
-#### Schema on `dispatch!` / `d!`
-
-Functions that accept a dispatch callback should annotate its argument with `*dispatch-op`:
-
-```cirru.no-check
-; respo.app.core/dispatch!
-defn dispatch! (op ? op-data)
-  ...
-schema $ :: :fn
-  {} (:return :unit)
-    :args $ [] 'respo.app.schema/Op (:: :optional :dynamic)
-
-; Event handler parameter uses type slot reference
-defn on-keydown (cursor state)
-  %{} respo.schema/RespoListener (:name :on-keydown)
-    :handler $ fn (event dispatch!)  ; dispatch! typed via *dispatch-op slot
-      ...
-schema $ :: :fn
-  {} (:return 'respo.schema/RespoListener)
-    :args $ [] :list :map
-; (handler schema uses 'respo.schema/EventHandler which takes Fn(*dispatch-op -> unit))
+```bash
+cr config set-type-slot :dispatch-op app.schema/Op
+cr config set-type-slot --entry test :dispatch-op app.test-schema/TestOp
+cr config type-slots
 ```
 
-#### Usage in Components — Short Syntax
+The path must be a full `namespace/definition`. Named entries are independent and do not inherit the default binding. No `bind-type` call or `with-type-slot` wrapper belongs in `main!`.
 
-Inside event handlers of DOM props (e.g., `:on-click`), write dispatch calls using the `::` shorthand. The compiler resolves the type slot and rewrites automatically:
+With the slot bound, Respo's `'*dispatch-op` callback schema types `d!`, and short dispatch tuples are validated against the configured enum:
 
 ```cirru.no-check
-; Short form (compiler rewrites to %:: Op :toggle (:id task))
 button $ {}
   :on-click $ fn (e d!)
     d! $ :: :toggle (:id task)
-
-; Also works for multi-arg variants
-input $ {}
-  :on-input $ fn (e d!)
-    let
-        text $ :value e
-      d! $ :: :update task-id text
 ```
 
-The auto-rewrite uses the `Op` enum type resolved from `*dispatch-op`. If you write an invalid variant, the compiler warns and blocks codegen:
-
-```
-[Warn] Enum `Op` does not have variant `:toogle`. Available variants: ["add", "clear", "toggle", ...]
-```
-
-#### How It Works (for debugging)
-
-1. `bind-type :dispatch-op Op` stores `TypeRef("respo.app.schema/Op")` in the type slot at preprocess time.
-2. When a function parameter has schema `Fn(*dispatch-op → unit)` (the EventHandler's second arg), `*dispatch-op` is resolved to the bound `Op` type and injected into the closure's scope as the type of `d!`.
-3. When `d! $ :: :variant ...` is preprocessed, the compiler sees `d!` has type `Fn(Op → unit)`, resolves `Op`, and rewrites `:: :variant` → `%:: Op :variant`.
-4. The variant name is validated against the enum definition.
-
-#### Common Pitfalls
-
-- `bind-type` must be called **before** preprocessing components that use it (i.e., early in `main!`).
-- Writing `%:: Op :variant` manually still works and is equivalent.
-- Type-slot-based shorthand only activates when `d!` has an inferred `Fn` type with a TypeSlot argument — if the schema is missing, the rewrite is silently skipped (no error, just no auto-rewrite).
-- The test entry point (`respo.test.main/main!`) does not call `bind-type`, so type-slot rewrites are inactive during tests. This is expected — test components use direct `%:: Op :variant` calls.
+The compiler resolves this like `%:: app.schema/Op :toggle ...` and checks the variant name, payload count, and payload types. If shorthand is not checked, inspect `cr config type-slots` and the callback schema; a dynamic callback provides no enum evidence.
 
 ---
 

--- a/docs/Respo-Agent.md
+++ b/docs/Respo-Agent.md
@@ -33,7 +33,7 @@ The Respo project is a virtual DOM library written in Calcit-js, containing:
 - **Compiled source**: `calcit.cirru` (13806 lines) - full AST representation
 - **Namespaces**: 33 total namespaces organized by functionality
 - **Version**: 0.16.21
-- **Dependencies**: memof (memoization), lilac (UI utilities), calcit-test (testing)
+- **Dependencies**: calcit-test (testing)
 
 ### Core Namespace Organization
 
@@ -269,8 +269,12 @@ list->
 ```
 
 Use stable domain IDs as keys. A `nil` key deliberately bypasses memoization. Call
-`clear-cache!` during hot reload to clear both managed component caches and legacy
-`memof` caches.
+`clear-cache!` during hot reload to clear Respo's managed component caches.
+
+Applications do not need `memof` for component memoization. For the complete
+`render-with!` setup, cache semantics, and migration rules for `memof1-call-by`,
+`memof1-call`, and `memof1-as`, see
+[Render list: memoization and memof migration](guide/render-list.md#memoizing-components).
 
 ### 5. Styling Pattern
 

--- a/docs/guide/render-list.md
+++ b/docs/guide/render-list.md
@@ -6,9 +6,12 @@ category: "ecosystem"
 aliases:
   - "render list"
   - "list rendering"
+  - "component memoization"
+  - "memof migration"
 entry_for:
   - "list->"
   - "keyed list"
+  - "memo-comp-by"
 ---
 
 ## Render list
@@ -51,3 +54,88 @@ list->
 ```
 
 Child elements are rendered in the order that items appear in the list. Diffing is not very fast, so don't make the list too large.
+
+## Memoizing components
+
+Business applications can use Respo's built-in `memo-comp-by` to avoid rebuilding
+an unchanged component subtree. Import `render-with!` and `memo-comp-by` from
+`respo.core`; no `memof` dependency or import is required.
+
+The application render entry must build its tree inside the zero-argument function
+passed to `render-with!`:
+
+```cirru.no-check
+; ns app.main $ :require
+  respo.core :refer $ render-with! memo-comp-by
+
+defn render-app! ()
+  render-with! mount-target
+    fn () $ comp-container @*store
+    , dispatch!
+```
+
+Call `memo-comp-by` where the component is added to the tree. Its arguments are the
+stable key, the component function, and the complete component argument list:
+
+```cirru.no-check
+list->
+  {} (:class-name |task-list)
+  -> tasks .to-list $ map
+    fn (task)
+      let
+          task-id $ :id task
+        [] task-id $ memo-comp-by task-id comp-task (>> states task-id) task
+```
+
+The cache identity includes the component function and key. The cached `Component`
+is reused only when the full argument list is unchanged. Use a stable domain ID as
+the key; an array index is unsafe when items can be inserted, removed, or reordered.
+Passing `nil` deliberately bypasses caching.
+
+`render-with!` starts and finishes the memo frame automatically. At the end of the
+frame, Respo removes cached keys that were not visited, so business code must not
+call frame lifecycle functions itself. During hot reload, call `clear-cache!` before
+rendering again so components defined by the old code are not retained:
+
+```cirru.no-check
+defn reload! ()
+  clear-cache!
+  render-app!
+```
+
+Use `memo-comp-by` only for component functions returning a Respo `Component`. It is
+not a general-purpose replacement for memoizing data transformations, network
+requests, or arbitrary expressions.
+
+## Migrating from memof
+
+For component rendering, the common migration is:
+
+| Old `memof.once` usage | Respo replacement |
+| --- | --- |
+| `memof1-call-by key comp-f & args` | `memo-comp-by key comp-f & args` |
+| `begin-memof1-frame!` / `finish-memof1-frame!` | Remove them; use `render-with!` at the application render entry |
+| `reset-memof1-caches!` during hot reload | `respo.core/clear-cache!` |
+| `memof.once` import and `memof/` module | Remove them when no non-component usage remains |
+
+For example, change a memoized list child from:
+
+```cirru.no-check
+[] task-id $ memof1-call-by task-id comp-task (>> states task-id) task
+```
+
+to:
+
+```cirru.no-check
+[] task-id $ memo-comp-by task-id comp-task (>> states task-id) task
+```
+
+Then make sure the top-level render uses `render-with!`, remove the `memof.once`
+require rule, remove `memof/` from the entry's modules, and remove
+`calcit-lang/memof` from `deps.cirru` if the project no longer uses it elsewhere.
+
+There is no direct Respo replacement for `memof1-call` without a business key or
+for `memof1-as` around an arbitrary expression. If those calls produce components,
+choose a stable domain key and rewrite them with `memo-comp-by`. If they cache
+non-component computations, keep `memof` or adopt another cache appropriate to that
+data lifecycle; do not pass a non-Component result to `memo-comp-by`.

--- a/docs/guide/type-slots.md
+++ b/docs/guide/type-slots.md
@@ -1,0 +1,148 @@
+---
+title: "Typed dispatch with type slots"
+summary: "Bind Respo's dispatch operation type once per Calcit entry so d! shorthand is checked across the whole component call graph"
+scope: "module"
+kind: "guide"
+category: "ecosystem"
+aliases:
+  - "type slot"
+  - "typed dispatch"
+  - "dispatch op"
+  - "dispatch-op"
+  - "d! enum shorthand"
+entry_for:
+  - "cr config set-type-slot"
+  - "*dispatch-op"
+  - "d! $ ::"
+  - "invalid dispatch variant"
+---
+
+# Typed dispatch with type slots
+
+Respo declares the `:dispatch-op` type slot in `respo.schema`. An application binds that slot to its own `Op` enum once for each Calcit entry. The compiler can then type the `d!` callback throughout the reachable component tree without adding a generic type parameter to every component, element, listener, and render helper.
+
+## Application setup
+
+Define the application operation enum as usual, then bind its full definition path in the default entry configuration:
+
+```bash
+cr config set-type-slot :dispatch-op app.schema/Op
+cr config type-slots
+```
+
+The command writes this shape to `calcit.cirru`:
+
+```cirru.no-check
+:configs $ {}
+  :init-fn |app.main/main!
+  :type-slots $ {}
+    :dispatch-op |app.schema/Op
+```
+
+The type path must contain both namespace and definition. A bare `Op` is rejected because configuration is loaded before Calcit expressions are evaluated.
+
+No type-slot call belongs in `main!`:
+
+```cirru.no-check
+defn main! ()
+  render-app!
+```
+
+The selected entry installs its bindings before any definition is preprocessed, so the same choice applies to the whole reachable call graph and does not depend on which component is compiled first.
+
+## Named entries are independent
+
+A named entry is a complete configuration and does not inherit `:configs.type-slots`. Bind the slot explicitly when another entry compiles Respo components:
+
+```bash
+cr config set-type-slot --entry test :dispatch-op app.test-schema/TestOp
+cr config type-slots --entry test
+```
+
+Client and server entries can bind the same slot to different enums because each invocation selects one entry:
+
+```bash
+cr config set-type-slot :dispatch-op app.schema/ClientOp
+cr config set-type-slot --entry server :dispatch-op app.schema/ServerOp
+```
+
+Use `:dynamic` as an explicit opt-out when an entry intentionally does not want dispatch checking:
+
+```bash
+cr config set-type-slot --entry test :dispatch-op :dynamic
+```
+
+## Dispatch shorthand
+
+Respo's event handler schema accepts `'*dispatch-op`. Once the entry binds that slot, the compiler knows that `d!` accepts the configured enum and can resolve the short tuple syntax:
+
+```cirru.no-check
+button $ {}
+  :on-click $ fn (event d!)
+    d! $ :: :toggle (:id task)
+```
+
+For `app.schema/Op`, this is checked like `%:: app.schema/Op :toggle (:id task)`. The compiler validates the variant name, payload count, and payload types. Writing an unknown variant such as `:: :toogle` blocks code generation with the enum diagnostic.
+
+An explicit enum tuple remains valid and can be useful outside an inferred dispatch callback:
+
+```cirru.no-check
+d! $ %:: app.schema/Op :toggle (:id task)
+```
+
+If `d! $ :: ...` is not checked, first confirm that the selected entry binds `:dispatch-op` and that the callback schema still flows from a Respo event/listener API. A callback that has fallen back to `:dynamic` cannot drive the shorthand rewrite.
+
+## Migration from older setup
+
+Older applications may contain `bind-type` or wrap an entry body with `with-type-slot`:
+
+```cirru.no-check
+defn main! () $ with-type-slot (:dispatch-op Op)
+  render-app!
+```
+
+Move the binding to config and remove the wrapper:
+
+```bash
+cr config set-type-slot :dispatch-op app.schema/Op
+```
+
+`with-type-slot` remains a compile-time compatibility form in Calcit and is erased for both single and multiple bodies; adding `do` is no longer required. Entry configuration is preferred because it states the build-wide type choice directly and avoids making a global compile decision look like runtime or lexical behavior. `bind-type` is obsolete and should not be used.
+
+## Verification and troubleshooting
+
+After changing the enum or entry binding, run:
+
+```bash
+cr config type-slots
+cr --check-only
+cr js
+```
+
+For a named entry, pass the same selection to inspection and compilation:
+
+```bash
+cr config type-slots --entry server
+cr --entry server --check-only
+cr --entry server js
+```
+
+Common failures:
+
+- `expects a full namespace/definition path`: use `app.schema/Op`, not `Op`.
+- configured definition is missing: ensure the namespace belongs to the project or to a module listed by that same entry.
+- default entry works but a named entry does not: named entries do not inherit the default binding or module list.
+- shorthand silently stays dynamic: inspect the event/listener callback schema and ensure it accepts `'*dispatch-op`.
+- Rust execution works but generated JS fails around old slot runtime code: align the Calcit CLI and `@calcit/procs` versions, then regenerate JS; current Calcit erases `with-type-slot` before codegen.
+
+## Reusing this guide with `cr docs`
+
+When Respo is installed as a module, search and reopen this page instead of copying its rules into each application:
+
+```bash
+cr docs search 'typed dispatch' --module respo.calcit
+cr docs search 'dispatch-op' --module respo.calcit
+cr docs read type-slots.md --full --module respo.calcit
+```
+
+Use `cr docs scopes` if the installed module scope has a different displayed name.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@calcit/procs": "^0.12.54"
+    "@calcit/procs": "^0.12.55"
   },
   "scripts": {
     "test": "cr --init-fn 'respo.test.main/main!' js && node test.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@calcit/procs": "^0.12.53"
+    "@calcit/procs": "^0.12.54"
   },
   "scripts": {
     "test": "cr --init-fn 'respo.test.main/main!' js && node test.mjs",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,14 +5,14 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@calcit/procs@npm:^0.12.54":
-  version: 0.12.54
-  resolution: "@calcit/procs@npm:0.12.54"
+"@calcit/procs@npm:^0.12.55":
+  version: 0.12.55
+  resolution: "@calcit/procs@npm:0.12.55"
   dependencies:
     "@calcit/ternary-tree": "npm:0.0.26"
     "@cirru/parser.ts": "npm:^0.0.9"
     "@cirru/writer.ts": "npm:^0.1.9"
-  checksum: 10c0/919035d673c6faf8489691edefce322e2cc4db557c5037a21c27a82c0051c3cb81a534e21f7610d62915813b5f8fa60ca78c9717a76e838ebdabd81161ab1123
+  checksum: 10c0/8476617907a107747adc11767f2db05f1bef1dbc257988943a97d39f678e99bcaa43db68a47d681176152d23d9b5eb73d16c07523394720abd6d5aef1bb62db7
   languageName: node
   linkType: hard
 
@@ -984,7 +984,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    "@calcit/procs": "npm:^0.12.54"
+    "@calcit/procs": "npm:^0.12.55"
     bottom-tip: "npm:^0.1.5"
     vite: "npm:^8.0.3"
   languageName: unknown

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,14 +5,14 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@calcit/procs@npm:^0.12.53":
-  version: 0.12.53
-  resolution: "@calcit/procs@npm:0.12.53"
+"@calcit/procs@npm:^0.12.54":
+  version: 0.12.54
+  resolution: "@calcit/procs@npm:0.12.54"
   dependencies:
     "@calcit/ternary-tree": "npm:0.0.26"
     "@cirru/parser.ts": "npm:^0.0.9"
     "@cirru/writer.ts": "npm:^0.1.9"
-  checksum: 10c0/d6f1d94bb582789a761c007d8f6d654975ef1748229fe81c41a2f51e371188ef7b2660109830360883ca2d16dec83a63db8cfdf5bce9390ae336d5e9554846b7
+  checksum: 10c0/919035d673c6faf8489691edefce322e2cc4db557c5037a21c27a82c0051c3cb81a534e21f7610d62915813b5f8fa60ca78c9717a76e838ebdabd81161ab1123
   languageName: node
   linkType: hard
 
@@ -984,7 +984,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    "@calcit/procs": "npm:^0.12.53"
+    "@calcit/procs": "npm:^0.12.54"
     bottom-tip: "npm:^0.1.5"
     vite: "npm:^8.0.3"
   languageName: unknown


### PR DESCRIPTION
## Summary

- normalize list/map child and prop collections during VDOM diffing and effect traversal
- preserve record state across repeated partial merges
- omit or remove nil DOM attributes, including data-comp and data-name
- ignore local .calcit state and add regression coverage
- bind Respo dispatch-op through entry-level type-slots configuration
- align deps.cirru and @calcit/procs with Calcit 0.12.54
- replace obsolete bind-type guidance with a reusable typed-dispatch module guide

## Validation

- Calcit 0.12.54 config type-slots and check-only
- Respo test-entry JS codegen and node test.mjs
- main-entry JS codegen
- all Markdown code blocks
- yarn vite build --base=./

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved rendering compatibility for map-based children and properties.
  - Expanded state merging support for map and record data.
  - Added guidance for typed dispatch with type slots.
- **Bug Fixes**
  - Clearing dataset values now removes the corresponding attributes.
  - Improved transitions between list and map representations during rendering.
- **Documentation**
  - Updated memoization and migration guidance.
  - Refreshed README and developer documentation.
- **Tests**
  - Expanded coverage for state merging, rendering transitions, and attribute handling.
- **Chores**
  - Updated tool versions and ignore rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->