### PR TITLE
fix: restore persisted task structs safely

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ App initialization:
 let
     *store $ atom $ {} (:point 0) (:states {})
     updater $ fn (store op)
-      tag-match op
+      match op
         (:TODO a b) store
         _ store
     dispatch! $ fn (op)

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -1910,14 +1910,14 @@
         |update-states-kv $ %{} :CodeEntry (:doc "|a quick dirty trick to partially update component state.\n\nnotice: need to handle empty state manually.")
           :code $ quote
             defn update-states-kv (store cursor k v)
-              update-in store
-                concat ([] :states) cursor $ [] :data
-                fn (state-option)
-                  option:fold state-option
-                    fn () $ do (js/console.warn |:states-kv-missing-state) nil
-                    fn (state)
-                      if (map? state) (assoc state k v)
-                        do (js/console.warn |:states-kv-invalid-state state) state
+              let
+                  path $ concat ([] :states) cursor ([] :data)
+                  state-option $ get-in store path
+                assoc-in store path $ option:fold state-option
+                  fn () $ do (js/console.warn |:states-kv-missing-state) nil
+                  fn (state)
+                    if (map? state) (assoc state k v)
+                      do (js/console.warn |:states-kv-invalid-state state) state
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'T)
@@ -1926,16 +1926,13 @@
         |update-states-merge $ %{} :CodeEntry (:doc |)
           :code $ quote
             defn update-states-merge (store cursor state0 changes)
-              update-in store
-                concat ([] :states) cursor $ [] :data
-                fn (state-option)
-                  option:fold state-option
-                    fn () $ noted |merge-base-initial-state (merge state0 changes)
-                    fn (state)
-                      if
-                        or (map? state) (struct? state)
-                        noted |merge-base-latest-state $ merge state changes
-                        do (js/console.warn |unknown-state-to-merge state) state
+              let
+                  path $ concat ([] :states) cursor ([] :data)
+                  state $ option:unwrap-or (get-in store path) state0
+                assoc-in store path $ if
+                  or (map? state) (struct? state)
+                  noted |merge-base-latest-state $ merge state changes
+                  do (js/console.warn |unknown-state-to-merge state) state
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'T)
@@ -1992,23 +1989,35 @@
         |normalize-task $ %{} :CodeEntry (:doc |)
           :code $ quote
             defn normalize-task (data)
-              if
-                or (struct? data) (map? data)
-                let
-                    id $ get data :id
-                    text $ get data :text
-                    done? $ get data :done?
-                  if
-                    and (option:some? id) (option:some? text) (option:some? done?)
-                      string? $ option:unwrap id
-                      string? $ option:unwrap text
-                      bool? $ option:unwrap done?
-                    %some $ %{} Task
-                      :id $ unsafe-coerce (option:unwrap id) String
-                      :text $ unsafe-coerce (option:unwrap text) String
-                      :done? $ unsafe-coerce (option:unwrap done?) Bool
-                    %none
-                %none
+              cond
+                  struct? data
+                  let
+                      id $ &struct:get data :id
+                      text $ &struct:get data :text
+                      done? $ &struct:get data :done?
+                    if
+                      and (string? id) (string? text) (bool? done?)
+                      %some $ %{} Task
+                        :id $ unsafe-coerce id String
+                        :text $ unsafe-coerce text String
+                        :done? $ unsafe-coerce done? Bool
+                      %none
+                (map? data)
+                  let
+                      id $ get data :id
+                      text $ get data :text
+                      done? $ get data :done?
+                    if
+                      and (option:some? id) (option:some? text) (option:some? done?)
+                        string? $ option:unwrap id
+                        string? $ option:unwrap text
+                        bool? $ option:unwrap done?
+                      %some $ %{} Task
+                        :id $ unsafe-coerce (option:unwrap id) String
+                        :text $ unsafe-coerce (option:unwrap text) String
+                        :done? $ unsafe-coerce (option:unwrap done?) Bool
+                      %none
+                true %none
           :examples $ []
           :schema $ :: 'Fn
             {}
@@ -3654,7 +3663,7 @@
       :defs $ {}
         |main! $ %{} :CodeEntry (:doc |)
           :code $ quote
-            defn main! () (html/run-tests) (test-pick-attrs) (test-pick-event) (memo/run-tests) (primitives/run-tests) (test-find-props-diffs) (test-pair-representation-transitions) (test-update-states-merge-record) (test-dom-fallback-values)
+            defn main! () (html/run-tests) (test-pick-attrs) (test-pick-event) (memo/run-tests) (primitives/run-tests) (test-find-props-diffs) (test-pair-representation-transitions) (test-update-states-merge-record) (test-dom-fallback-values) (test-normalize-task-struct)
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Unit)
@@ -3686,6 +3695,17 @@
                 is $ =
                   option:unwrap $ first @effects
                   :: :replace-prop ([]) ([]) ([] :class-name |new)
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |test-normalize-task-struct $ %{} :CodeEntry (:doc |)
+          :code $ quote
+            deftest test-normalize-task-struct $ testing |task_structs_restore_from_local_storage
+              let
+                  task $ %{} respo.app.schema/Task (:id |gen_id_39_1769789437265) (:text |saved) (:done? false)
+                  normalized $ option:unwrap (normalize-task task)
+                is $ = |gen_id_39_1769789437265 (&struct:get normalized :id)
+                is $ = |saved (&struct:get normalized :text)
+                is $ = false (&struct:get normalized :done?)
           :examples $ []
           :schema $ :: 'Dynamic
         |test-pair-representation-transitions $ %{} :CodeEntry (:doc |)
@@ -3765,6 +3785,7 @@
             respo.test.primitives :as primitives
             respo.util.format :refer $ get-style-value
             respo.util.dom :refer $ text-width
+            respo.main :refer $ normalize-task
     |respo.test.memo $ %{} :FileEntry
       :defs $ {}
         |*render-count $ %{} :CodeEntry (:doc |)

--- a/docs/Respo-Agent.md
+++ b/docs/Respo-Agent.md
@@ -202,7 +202,7 @@ defn dispatch! (op)
 
 ; Updater function pattern
 defn updater (store op)
-  tag-match op
+  match op
     (:action-name value) $
       assoc store :data (process-action (:data store) value)
     (:nested-action id op2) $
@@ -410,7 +410,7 @@ Components can define custom listeners that respond to events sent via `send-to-
 defn on-keydown (cursor state)
   %{} respo.schema/RespoListener (:name :on-keydown)
     :handler $ fn (event dispatch!)
-      tag-match event $
+      match event $
         :keydown info
         when
           and
@@ -535,8 +535,8 @@ cr query def 'respo.app.comp.container/comp-container'
 **Solution Pattern**:
 
 ```cirru.no-check
-; Verify tag-match pattern matches dispatched action
-tag-match op
+; Verify native match patterns against the dispatched action
+match op
   (:action-name params) $
     ; Make sure return value is updated store
     assoc store :data new-value


### PR DESCRIPTION
## Summary
- restore persisted task structs without treating struct fields as Options
- avoid update-in's enum-only helper path for component state updates
- update match examples and add regression coverage for task restoration

## Validation
- cr js
- cr --check-only
- yarn test *(blocked before test execution by an existing extensionless calcit.build-errors import in generated output)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved state updates and restoration when working with structured tasks.
  - Ensured merged state uses the provided initial value when no saved state exists.
  - Added validation for structured task data.

- **Documentation**
  - Updated examples to use the native `match` pattern instead of `tag-match`.
  - Revised guidance for state management, event handling, and debugging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->