### PR TITLE
chore: release 0.16.64

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ### Project Info
 
-- **Version**: 0.16.63
+- **Version**: 0.16.64
 - **Init Function**: `respo.main/main!`
 - **Reload Function**: `respo.main/reload!`
 - **Core Namespaces**: 33 namespaces providing virtual DOM, rendering, components, and utilities

--- a/deps.cirru
+++ b/deps.cirru
@@ -1,3 +1,3 @@
 
-{} (:calcit-version |0.13.2)
+{} (:calcit-version |0.13.4)
   :dependencies $ {} (|calcit-lang/calcit-test |0.0.6)


### PR DESCRIPTION
## Summary
- bump Respo version from 0.16.63 to 0.16.64
- use released Calcit 0.13.4 for project tooling

## Verification
- `yarn test`
- `yarn check-docs` (126 blocks passed)
- PR #90 DOM FFI Actions passed before merge