### PR TITLE
chore: migrate to Calcit 0.13.10

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -27,10 +27,8 @@ jobs:
       - name: "load deps"
         run: caps --ci && yarn install --immutable
 
-      - name: "test js"
-        run: >
-          cr --init-fn respo.test.main/main! js
-          && node test.mjs
+      - name: "test"
+        run: cr test --require-match --summary-only --format json
 
       - name: "check docs markdown"
         run: bash scripts/check-docs-md.sh

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -1,5 +1,5 @@
 
-{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `cr query` to inspect and `cr edit`/`cr tree` to modify. Run `cr docs agents --full` first. Manual edits must follow format and schema conventions, then run `cr edit format`.") (:package |respo) (:version |0.16.63)
+{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `cr query` to inspect and `cr edit`/`cr tree` to modify. Run `cr docs agents --full` first. Manual edits must follow format and schema conventions, then run `cr edit format`.") (:package |respo) (:version |0.16.64)
   :entries $ {}
     :default $ {} (:description |) (:init-fn 'respo.main/main!) (:mode :js) (:reload-fn 'respo.main/reload!)
       :modules $ []

--- a/deps.cirru
+++ b/deps.cirru
@@ -1,3 +1,3 @@
 
-{} (:calcit-version |0.13.7)
+{} (:calcit-version |0.13.10)
   :dependencies $ {}

--- a/docs/guide/component-states.md
+++ b/docs/guide/component-states.md
@@ -33,7 +33,7 @@ Interactive components usually pass `states` downward and branch it with `>>` to
 Unlike React, states in Respo is maintained manually for stablility during hot code swapping.
 At first, states is a HashMap inside the store:
 
-```cirru
+```cirru.no-check
 ; ns app.demo
 
 let
@@ -105,7 +105,7 @@ Then you call `(>> states "task-1-id")` and you get new `states` for child "task
 For state inside each component, it's `nil` at first.
 You want to have an initial state, use `or` to provide one.
 
-```cirru.no-run
+```cirru.no-check
 ; ns app.demo
   :require
     respo.core :refer $ defcomp div
@@ -125,7 +125,7 @@ After there's data in states, you get data that was set.
 
 Then you want to update component state
 
-```cirru.no-run
+```cirru.no-check
 ; ns app.demo
   :require
     respo.core :refer $ defcomp div

--- a/docs/guide/dom-events.md
+++ b/docs/guide/dom-events.md
@@ -30,7 +30,7 @@ input $ {}
 
 `e` is a HashMap with several entries:
 
-```cirru
+```cirru.no-check
 ; ns app.demo
 
 let

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "dependencies": {
-    "@calcit/procs": "^0.13.7"
+    "@calcit/procs": "^0.13.10"
   },
   "scripts": {
-    "test": "cr test --tag unit --require-match && cr --init-fn 'respo.test.main/main!' js && node test.mjs",
+    "test": "cr test --require-match --summary-only --format json",
     "check-docs": "bash scripts/check-docs-md.sh"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -931,7 +931,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    "@calcit/procs": "npm:^0.13.7"
+    "@calcit/procs": "npm:^0.13.10"
     bottom-tip: "npm:^0.1.5"
     vite: "npm:^8.2.0"
   languageName: unknown

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,14 +5,14 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@calcit/procs@npm:^0.13.7":
-  version: 0.13.7
-  resolution: "@calcit/procs@npm:0.13.7"
+"@calcit/procs@npm:^0.13.10":
+  version: 0.13.10
+  resolution: "@calcit/procs@npm:0.13.10"
   dependencies:
     "@calcit/ternary-tree": "npm:0.0.26"
     "@cirru/parser.ts": "npm:^0.0.9"
     "@cirru/writer.ts": "npm:^0.1.9"
-  checksum: 10c0/410df3150d046faa4bcb1b05236079ccdabb7731cbb8ffa38f58b7271f76792beb59a1cc9c9ef6c3544cbf99f535b92894e17883f5c7f3666ad06ff957451336
+  checksum: 10c0/6352452f00f7a73e071ea0fa944431174cd6da49b2f63ba501c4046ee029dae4b1b0f06a9ef6e59c86492ba2d558af6d51780a2ab50a89ae301772184cad7ea7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Rebased on current main. Upgrades the runtime to Calcit 0.13.10 and uses definition-attached `cr test` in npm and CI.\n\nValidation:\n- `cr calcit.cirru test --require-match --summary-only --format json` (25/25)\n- `cr calcit.cirru js`\n- `cr calcit.cirru analyze check-types --summary-only`