### PR TITLE
chore: upgrade to Calcit 0.13.13

### DIFF
--- a/deps.cirru
+++ b/deps.cirru
@@ -1,3 +1,3 @@
 
-{} (:calcit-version |0.13.10)
+{} (:calcit-version |0.13.13)
   :dependencies $ {}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@calcit/procs": "^0.13.10"
+    "@calcit/procs": "^0.13.13"
   },
   "scripts": {
     "test": "cr test --require-match --summary-only --format json",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,14 +5,14 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@calcit/procs@npm:^0.13.10":
-  version: 0.13.10
-  resolution: "@calcit/procs@npm:0.13.10"
+"@calcit/procs@npm:^0.13.13":
+  version: 0.13.13
+  resolution: "@calcit/procs@npm:0.13.13"
   dependencies:
     "@calcit/ternary-tree": "npm:0.0.26"
     "@cirru/parser.ts": "npm:^0.0.9"
     "@cirru/writer.ts": "npm:^0.1.9"
-  checksum: 10c0/6352452f00f7a73e071ea0fa944431174cd6da49b2f63ba501c4046ee029dae4b1b0f06a9ef6e59c86492ba2d558af6d51780a2ab50a89ae301772184cad7ea7
+  checksum: 10c0/2f05ccfef08bc971aea97536bf8dd3cb4f1edc67acad8d377b98ecd015a0b01ef674193d92b218c1623b56f772f09e19733b5ec45ab01f4dfba35a4ceadd6295
   languageName: node
   linkType: hard
 
@@ -931,7 +931,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    "@calcit/procs": "npm:^0.13.10"
+    "@calcit/procs": "npm:^0.13.13"
     bottom-tip: "npm:^0.1.5"
     vite: "npm:^8.2.0"
   languageName: unknown


### PR DESCRIPTION
Upgrades the Calcit runtime and resolved module dependencies to 0.13.13.\n\nValidated locally with `caps --ci` (project-scoped module links) and `cr js`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Calcit runtime version.
  * Updated the Calcit procedures package to the latest compatible version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->