### PR TITLE
ci: validate current Calcit project layout

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -27,15 +27,23 @@ jobs:
       - name: "load deps"
         run: caps --ci && yarn install --immutable
 
+      - name: Validate Calcit snapshot and type baseline
+        run: |
+          cr calcit.cirru edit format
+          git diff --exit-code -- calcit.cirru
+          cr calcit.cirru --check-only
+          cr calcit.cirru analyze check-types --summary-only --format json
+          cr calcit.cirru analyze weak-types --only schema-dynamic,code-dynamic --intent unresolved --summary-only --format json
+
       - name: "test"
-        run: cr test --require-match --summary-only --format json
+        run: cr calcit.cirru test --require-match --summary-only --format json
 
       - name: "check docs markdown"
         run: bash scripts/check-docs-md.sh
 
       - name: "build js"
         run: >
-          cr js
+          cr calcit.cirru js
           && yarn vite build --base=./
 
       - name: Deploy to server

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 
 .compact-inc.cirru
+compact.cirru
 .calcit-error.cirru
 
 js-out/


### PR DESCRIPTION
Completes the current Calcit project upgrade workflow after the 0.13.13 dependency update.

- preserves the canonical single calcit.cirru Snapshot and ignores the obsolete compact.cirru filename
- pins all CLI calls to calcit.cirru
- runs caps --ci, canonical format/diff, check-only, type coverage, and unresolved weak-type summaries before tests and JS/Vite build

Validated locally: caps --ci, format/diff, check-only, type analyses, 25 tests, 111 documentation snippets, JS codegen, and Vite build.