### PR TITLE
fix: make DOM comparison Option-safe

### DIFF
--- a/202608131232-dom-option-types.md
+++ b/202608131232-dom-option-types.md
@@ -1,0 +1,5 @@
+# Make DOM comparison Option-safe
+
+- Replace implicit VDOM map field access in `compare-to-dom!` with `get` and `option:unwrap-or` defaults.
+- Preserve SSR diagnostics for missing names, attributes, and children while making nullable data explicit to the 0.13.13 type checker.
+- This unblocks older modules such as respo-value when they are checked through the current Respo dependency.

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -4591,7 +4591,7 @@
                   .-length $ unsafe-coerce (.-children element) JsObject
                 let
                     maybe-html $ :innerHTML
-                      pairs-map $ option:unwrap-or (get vdom :attrs) {}
+                      pairs-map $ option:unwrap-or (get vdom :attrs) ({})
                   if (some? maybe-html)
                     when
                       = maybe-html $ .-innerHTML element

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -4577,7 +4577,8 @@
                 map :name $ vals (:children vdom)
               ; js/console.log element
               let
-                  virtual-name $ turn-string (:name vdom)
+                  virtual-name $ turn-string
+                    option:unwrap-or (get vdom :name) |unknown
                   real-name $ .!toLowerCase
                     unsafe-coerce (.-tagName element) JsObject
                 when (not= virtual-name real-name)
@@ -4586,23 +4587,27 @@
                     , element
               if
                 not=
-                  count $ :children vdom
+                  count $ option:unwrap-or (get vdom :children) []
                   .-length $ unsafe-coerce (.-children element) JsObject
                 let
                     maybe-html $ :innerHTML
-                      pairs-map $ :attrs vdom
+                      pairs-map $ option:unwrap-or (get vdom :attrs) {}
                   if (some? maybe-html)
                     when
                       = maybe-html $ .-innerHTML element
                       js/console.warn "|SSR checking: noticed dom containing innerHTML:" element
                     do (js/console.error "|SSR checking: children sizes do not match!")
-                      js/console.log |virtual: $ -> vdom :children (map last) (map :name) to-lispy-string
+                      js/console.log |virtual: $ ->
+                        option:unwrap-or (get vdom :children) []
+                        map last
+                        map :name
+                        , to-lispy-string
                       js/console.log |real: $ .-children element
                 let
                     real-children $ unsafe-coerce (.-children element) JsObject
                   loop
                       acc 0
-                      other-children $ :children vdom
+                      other-children $ option:unwrap-or (get vdom :children) []
                     when
                       not $ empty? other-children
                       compare-to-dom! (val-of-first other-children) (aget real-children acc)


### PR DESCRIPTION
Replace implicit VDOM field access in SSR DOM comparison with get/option:unwrap-or fallbacks. This keeps current runtime defaults while satisfying the 0.13.13 type checker and unblocks respo-value migration. Verified check-only, JS generation, and Vite build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved virtual DOM comparison when names, children, or attributes are missing.
  * Added safe fallback values while preserving diagnostics for SSR mismatches, including tag names, child counts, HTML content, and nested children.

* **Documentation**
  * Documented DOM comparison behavior and compatibility with older modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->