### PR TITLE
chore: upgrade Calcit to 0.13.15

### DIFF
--- a/calcit.cirru
+++ b/calcit.cirru
@@ -640,7 +640,7 @@
                   or (= action :mount) (= action :update)
                   let
                       disabled-commands $ noted "|copied event does not support `event.preventDefault()`, so we need to pass a set of configs"
-                        either (:disabled-commands options) (#{} |p |s)
+                        option:unwrap-or (get options :disabled-commands) (#{} |p |s)
                       handler $ fn (event)
                         if
                           and
@@ -648,9 +648,9 @@
                             or (.-ctrlKey event) (.-metaKey event)
                           .!preventDefault event
                         .!dispatchEvent el $ new js/KeyboardEvent (.-type event) event
-                    if-let
-                      prev-listener $ aget el dirty-field
-                      js/window.removeEventListener event-name prev-listener
+                    let
+                        prev-listener $ aget el dirty-field
+                      if (js-present? prev-listener) (js/window.removeEventListener event-name prev-listener)
                     aset el dirty-field handler
                     js/window.addEventListener event-name handler
                 (= action :unmount)

--- a/deps.cirru
+++ b/deps.cirru
@@ -1,3 +1,3 @@
 
-{} (:calcit-version |0.13.13)
+{} (:calcit-version |0.13.15)
   :dependencies $ {}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@calcit/procs": "^0.13.13"
+    "@calcit/procs": "^0.13.15"
   },
   "scripts": {
     "test": "cr test --require-match --summary-only --format json",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,14 +5,14 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@calcit/procs@npm:^0.13.13":
-  version: 0.13.13
-  resolution: "@calcit/procs@npm:0.13.13"
+"@calcit/procs@npm:^0.13.15":
+  version: 0.13.15
+  resolution: "@calcit/procs@npm:0.13.15"
   dependencies:
     "@calcit/ternary-tree": "npm:0.0.26"
     "@cirru/parser.ts": "npm:^0.0.9"
     "@cirru/writer.ts": "npm:^0.1.9"
-  checksum: 10c0/2f05ccfef08bc971aea97536bf8dd3cb4f1edc67acad8d377b98ecd015a0b01ef674193d92b218c1623b56f772f09e19733b5ec45ab01f4dfba35a4ceadd6295
+  checksum: 10c0/f37687aac090b2a286f916ea3c9d9cc173d4f606d1f02d5e57e192cbf375277a05bcd5f0a75d890b2827635dec9959034046ea626fda8900b8fe2c7f5c4c3e8a
   languageName: node
   linkType: hard
 
@@ -931,7 +931,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    "@calcit/procs": "npm:^0.13.13"
+    "@calcit/procs": "npm:^0.13.15"
     bottom-tip: "npm:^0.1.5"
     vite: "npm:^8.2.0"
   languageName: unknown


### PR DESCRIPTION
Bump calcit-version 0.13.13 → 0.13.15, sync @calcit/procs. check-only passes; 25/25 unit tests pass; JS codegen verified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard event handling when command settings are unavailable.
  * Prevented errors during cleanup when no previous keyboard listener exists.

* **Chores**
  * Updated the application’s underlying runtime and processing components to newer versions.
  * Includes compatibility and maintenance improvements from the updated packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->