### PR TITLE
chore: upgrade Calcit to 0.13.16 and fix make-element child type

### DIFF
--- a/calcit.cirru
+++ b/calcit.cirru
@@ -3321,7 +3321,8 @@
                             (listener-builder event-name) event coord
                             .!stopPropagation event
                   each child-elements $ fn (child-element)
-                    if (some? child-element) (.append-child! element child-element)
+                    if (some? child-element)
+                      .append-child! element $ unsafe-coerce child-element 'respo.dom/DomElement
                   , element
           :examples $ []
           :schema $ :: 'Fn

--- a/deps.cirru
+++ b/deps.cirru
@@ -1,3 +1,3 @@
 
-{} (:calcit-version |0.13.15)
+{} (:calcit-version |0.13.16)
   :dependencies $ {}


### PR DESCRIPTION
## Summary
- upgrade calcit-version to 0.13.16
- fix make-element to coerce child-element to DomElement, satisfying stricter trait checking in Calcit 0.13.16

Resolves the `append-child!` arg 2 trait warning that blocks all dependent Respo projects under Calcit 0.13.16.