### PR TITLE
chore: upgrade Respo core to Calcit 0.13.31

### DIFF
--- a/deps.cirru
+++ b/deps.cirru
@@ -1,4 +1,4 @@
 
-{} (:calcit-version |0.13.29)
-  :version |0.16.79
+{} (:calcit-version |0.13.31)
+  :version |0.16.82
   :dependencies $ {} (|calcit-lang/js-ffi |0.1.9)

--- a/history/2026082223-upgrade-01331.md
+++ b/history/2026082223-upgrade-01331.md
@@ -1,0 +1,4 @@
+# Upgrade Calcit 0.13.31
+
+- Update Respo core and `@calcit/procs` to the current Calcit runtime.
+- Bump the module version to `0.16.82` for a new stable tag.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@calcit/procs": "0.13.29"
+    "@calcit/procs": "0.13.31"
   },
   "scripts": {
     "test": "calcit calcit.cirru test --require-match --summary-only --format json",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,14 +5,14 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@calcit/procs@npm:0.13.29":
-  version: 0.13.29
-  resolution: "@calcit/procs@npm:0.13.29"
+"@calcit/procs@npm:0.13.31":
+  version: 0.13.31
+  resolution: "@calcit/procs@npm:0.13.31"
   dependencies:
     "@calcit/ternary-tree": "npm:0.0.26"
     "@cirru/parser.ts": "npm:^0.0.9"
     "@cirru/writer.ts": "npm:^0.1.9"
-  checksum: 10c0/d8db7c62054dda827557f1bd8c8d7a777c17b40bd43f51fb3b39c57386d1c1a41dad449b641201daa05ad14c38a423601c803b5d9eb3557ae0173ae1a03f570a
+  checksum: 10c0/7114144cf01c890b05538598b1ab2b2b9f201aa477ac17c4f708f3abfe49beb0a3889e305b08bce81b096a75d46f420b2ee005351a0ab1d6fad54f6655c79406
   languageName: node
   linkType: hard
 
@@ -931,7 +931,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    "@calcit/procs": "npm:0.13.29"
+    "@calcit/procs": "npm:0.13.31"
     bottom-tip: "npm:^0.1.5"
     vite: "npm:^8.2.0"
   languageName: unknown


### PR DESCRIPTION
同步最新 main 后升级 Calcit 及 @calcit/procs 到 0.13.31，已完成本地检查。