### PR TITLE
fix: complete Calcit upgrade review follow-up

### DIFF
--- a/deps.cirru
+++ b/deps.cirru
@@ -1,4 +1,4 @@
 
-{} (:calcit-version |0.13.31)
-  :version |0.16.82
+{} (:calcit-version |0.13.32)
+  :version |0.16.83
   :dependencies $ {} (|calcit-lang/js-ffi |0.1.9)

--- a/history/2026082223-upgrade-01331.md
+++ b/history/2026082223-upgrade-01331.md
@@ -1,4 +1,0 @@
-# Upgrade Calcit 0.13.31
-
-- Update Respo core and `@calcit/procs` to the current Calcit runtime.
-- Bump the module version to `0.16.82` for a new stable tag.

--- a/history/2026082300-upgrade-calcit-01332.md
+++ b/history/2026082300-upgrade-calcit-01332.md
@@ -1,0 +1,4 @@
+# Upgrade Calcit 0.13.32
+
+- Upgrade Respo core and package procs to the current stable Calcit release.
+- Keep the module version at 0.16.83 after the review follow-up.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@calcit/procs": "0.13.31"
+    "@calcit/procs": "0.13.32"
   },
   "scripts": {
     "test": "calcit calcit.cirru test --require-match --summary-only --format json",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,14 +5,14 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@calcit/procs@npm:0.13.31":
-  version: 0.13.31
-  resolution: "@calcit/procs@npm:0.13.31"
+"@calcit/procs@npm:0.13.32":
+  version: 0.13.32
+  resolution: "@calcit/procs@npm:0.13.32"
   dependencies:
     "@calcit/ternary-tree": "npm:0.0.26"
     "@cirru/parser.ts": "npm:^0.0.9"
     "@cirru/writer.ts": "npm:^0.1.9"
-  checksum: 10c0/7114144cf01c890b05538598b1ab2b2b9f201aa477ac17c4f708f3abfe49beb0a3889e305b08bce81b096a75d46f420b2ee005351a0ab1d6fad54f6655c79406
+  checksum: 10c0/87c8bafb6b0188f8310d615dfd5b98106379219f8e6774d5ba6e2877a438c882629f59522726bd8ca18c93b0bab91fbb1dc6111ebc726a870c751fadc3fd32a5
   languageName: node
   linkType: hard
 
@@ -931,7 +931,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    "@calcit/procs": "npm:0.13.31"
+    "@calcit/procs": "npm:0.13.32"
     bottom-tip: "npm:^0.1.5"
     vite: "npm:^8.2.0"
   languageName: unknown


### PR DESCRIPTION
Address the history naming review comment and bring Respo core from the previous 0.13.31 upgrade to Calcit 0.13.32 with a new stable module version.