### PR TITLE
feat: use option let for task normalization

### DIFF
--- a/calcit.cirru
+++ b/calcit.cirru
@@ -209,7 +209,7 @@
           :code $ quote
             defeffect effect-focus (pattern) (action parent at-place?)
               when (= action :mount)
-                if-let
+                when-let
                   target $ js-nullish->option (js/document.querySelector pattern)
                   .!select target
           :examples $ []
@@ -1750,13 +1750,16 @@
           :code $ quote
             defn make-render-scheduler (render! enqueue-option)
               let
-                  render-fn $ expect-function render! |[Respo/make-render-scheduler]-expected-render-function
+                  render-fn $ unsafe-coerce (expect-function render! |[Respo/make-render-scheduler]-expected-render-function) Fn
                   queue! $ option:fold enqueue-option
                     fn () shared/queue-microtask!
-                    fn (enqueue!) (expect-function enqueue! "|[Respo/make-render-scheduler] expected enqueue! as a function or nil")
+                    fn (enqueue!)
+                      unsafe-coerce (expect-function enqueue! "|[Respo/make-render-scheduler] expected enqueue! as a function or nil") Fn
                   *queued? $ atom false
-                fn () $ when (not @*queued?) (reset! *queued? true)
-                  queue! $ fn () (reset! *queued? false) (render-fn)
+                fn () $ do
+                  when (not @*queued?) (reset! *queued? true)
+                    queue! $ fn () (reset! *queued? false) (render-fn)
+                  , nil
           :examples $ []
             quote $ make-render-scheduler
               fn () nil
@@ -2120,24 +2123,26 @@
             defmacro defstyle (style-name rules)
               assert "|expected symbol of style-name" $ symbol? style-name
               warn-style-literals rules
-              if-let
+              when-let
                 query0 $ nth rules 1
-                assert "|expected rule 0 to be hashmap or symbol, use `defstyle` like:\n\n```cirru\ndefstyle style-demo $ {}\n  |& $ {}\n    :color :red\n```\n\nwhere `&` refers to current element.\n" $ if-let
-                  rule0 $ nth query0 1
-                  or (symbol? rule0)
-                    and (list? rule0)
-                      &let
-                        h $ option:unwrap (nth rule0 0)
-                        or (&= '{} h) (&= 'merge h)
-              if-let
+                assert "|expected rule 0 to be hashmap or symbol, use `defstyle` like:\n\n```cirru\ndefstyle style-demo $ {}\n  |& $ {}\n    :color :red\n```\n\nwhere `&` refers to current element.\n" $ option:fold (nth query0 1)
+                  fn () true
+                  fn (rule0)
+                    or (symbol? rule0)
+                      and (list? rule0)
+                        &let
+                          h $ option:unwrap (nth rule0 0)
+                          or (&= '{} h) (&= 'merge h)
+              when-let
                 query1 $ nth rules 2
-                assert "|expected rule 1 to be hashmap or symbol, use `defstyle` like:\n\n```cirru\ndefstyle style-demo $ {}\n  |& $ {} (:color :red)\n  \"|&:hover\" $ {}\n    :background-color :blue\n```\n\nwhere `&` refers to current element" $ if-let
-                  rule1 $ nth query1 1
-                  or (symbol? rule1)
-                    and (list? rule1)
-                      &let
-                        h $ option:unwrap (nth rule1 0)
-                        or (&= '{} h) (&= 'merge h)
+                assert "|expected rule 1 to be hashmap or symbol, use `defstyle` like:\n\n```cirru\ndefstyle style-demo $ {}\n  |& $ {} (:color :red)\n  \"|&:hover\" $ {}\n    :background-color :blue\n```\n\nwhere `&` refers to current element" $ option:fold (nth query1 1)
+                  fn () true
+                  fn (rule1)
+                    or (symbol? rule1)
+                      and (list? rule1)
+                        &let
+                          h $ option:unwrap (nth rule1 0)
+                          or (&= '{} h) (&= 'merge h)
               let
                   style-name-str $ str
                     -> (turn-string style-name) (&str:replace |! |_EX_) (&str:replace |? |_QU_)
@@ -2280,19 +2285,21 @@
                       states $ &struct:nth store 1 :states
                       state-option $ get-in states path
                     assoc store :states $ assoc-in states path
-                      option:fold state-option
-                        fn () $ do (js/console.warn |:states-kv-missing-state) nil
-                        fn (state)
+                      if (state-option .some?)
+                        let
+                            state $ state-option .unwrap
                           if (map? state) (assoc state k v)
                             do (js/console.warn |:states-kv-invalid-state state) state
+                        do (js/console.warn |:states-kv-missing-state) nil
                   let
                       map-path $ concat ([] :states) path
                       state-option $ get-in store map-path
-                    assoc-in store map-path $ option:fold state-option
-                      fn () $ do (js/console.warn |:states-kv-missing-state) nil
-                      fn (state)
+                    assoc-in store map-path $ if (state-option .some?)
+                      let
+                          state $ state-option .unwrap
                         if (map? state) (assoc state k v)
                           do (js/console.warn |:states-kv-invalid-state state) state
+                      do (js/console.warn |:states-kv-missing-state) nil
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'T)
@@ -3661,7 +3668,7 @@
                             collect! $ :: :effect-before-update next-coord n-coord
                               fn (target)
                                 method (effect-args old-effect) ([] :unmount target false)
-                      if-let (new-effect new-effect-option)
+                      when-let (new-effect new-effect-option)
                         when (= action :update)
                           let
                               method $ effect-method new-effect
@@ -3957,7 +3964,8 @@
           :code $ quote
             defn apply-dom-changes (changes mount-point listener-builder)
               let
-                  get-root $ fn () (.-firstElementChild mount-point)
+                  get-root $ fn ()
+                    unsafe-coerce (.-firstElementChild mount-point) 'respo.dom/DomElement
                 &doseq (op changes)
                   let-sugar
                       n-coord $ option:unwrap (nth op 2)

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -514,19 +514,16 @@
                         :done? $ unsafe-coerce done? Bool
                       %none
                 (map? data)
-                  let
+                  option:let
                       id $ get data :id
                       text $ get data :text
                       done? $ get data :done?
                     if
-                      and (option:some? id) (option:some? text) (option:some? done?)
-                        string? $ option:unwrap id
-                        string? $ option:unwrap text
-                        bool? $ option:unwrap done?
+                      and (string? id) (string? text) (bool? done?)
                       %some $ %{} Task
-                        :id $ unsafe-coerce (option:unwrap id) String
-                        :text $ unsafe-coerce (option:unwrap text) String
-                        :done? $ unsafe-coerce (option:unwrap done?) Bool
+                        :id $ unsafe-coerce id String
+                        :text $ unsafe-coerce text String
+                        :done? $ unsafe-coerce done? Bool
                       %none
                 true %none
           :examples $ []

--- a/deps.cirru
+++ b/deps.cirru
@@ -1,4 +1,4 @@
 
-{} (:calcit-version |0.13.37)
+{} (:calcit-version |0.13.38)
   :version |0.16.84
   :dependencies $ {} (|calcit-lang/js-ffi |0.1.9)

--- a/deps.cirru
+++ b/deps.cirru
@@ -1,4 +1,4 @@
 
-{} (:calcit-version |0.13.38)
+{} (:calcit-version |0.13.40)
   :version |0.16.84
   :dependencies $ {} (|calcit-lang/js-ffi |0.1.9)

--- a/history/20260823-option-let-migration.md
+++ b/history/20260823-option-let-migration.md
@@ -1,0 +1,4 @@
+# Option binding macro migration
+
+- Upgraded the project runtime declaration to Calcit 0.13.38.
+- Reworked `respo.app.task/normalize-task`'s map branch to use `option:let`: missing task fields short-circuit to `%none`, while existing payload type validation is unchanged.

--- a/history/20260823-option-let-migration.md
+++ b/history/20260823-option-let-migration.md
@@ -2,3 +2,4 @@
 
 - Upgraded the project runtime declaration to Calcit 0.13.38.
 - Reworked `respo.app.task/normalize-task`'s map branch to use `option:let`: missing task fields short-circuit to `%none`, while existing payload type validation is unchanged.
+- Made `comp-inspect`'s click handler explicitly return Unit after logging so the existing CI type gate passes under Calcit 0.13.38.

--- a/history/20260824-upgrade-calcit-01340.md
+++ b/history/20260824-upgrade-calcit-01340.md
@@ -1,0 +1,5 @@
+# Upgrade Calcit 0.13.40
+
+- Rebase the option-let migration onto Respo 0.16.84.
+- Synchronize `deps.cirru` and `@calcit/procs` with Calcit 0.13.40 so the CLI and generated JavaScript runtime use the same release.
+- Migrate side-effect Option handling to `when-let`, retain explicit boolean fallbacks in `defstyle`, and narrow validated JavaScript/function boundaries so the stricter shared `option:fold` return contract remains type-safe.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@calcit/procs": "0.13.37"
+    "@calcit/procs": "0.13.40"
   },
   "scripts": {
     "test": "calcit calcit.cirru test --require-match --summary-only --format json",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,14 +5,14 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@calcit/procs@npm:0.13.37":
-  version: 0.13.37
-  resolution: "@calcit/procs@npm:0.13.37"
+"@calcit/procs@npm:0.13.40":
+  version: 0.13.40
+  resolution: "@calcit/procs@npm:0.13.40"
   dependencies:
     "@calcit/ternary-tree": "npm:0.0.26"
     "@cirru/parser.ts": "npm:^0.0.9"
     "@cirru/writer.ts": "npm:^0.1.9"
-  checksum: 10c0/4357ec83fc18f26e8616c844662ea40e92ea62f4f827adb31de31a38dfeb3fc31f41eae535d839549847fa56b22c5543493aba9f858ac6d34ea880415eb98a3a
+  checksum: 10c0/026aea886fd950050ec3e08237da00a9dc2a2e5a9d8849ab36f85b17f6c367806cada9e422e5fdd28657e0ec2bdd4d783e8724dcc69ced7fecdfb0faf000230c
   languageName: node
   linkType: hard
 
@@ -931,7 +931,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    "@calcit/procs": "npm:0.13.37"
+    "@calcit/procs": "npm:0.13.40"
     bottom-tip: "npm:^0.1.5"
     vite: "npm:^8.2.0"
   languageName: unknown


### PR DESCRIPTION
Upgrade to Calcit 0.13.38 and use `option:let` to bind required task-map fields. Missing fields propagate `%none`; existing payload validation and Task construction stay unchanged.

Validated with 25/25 definition tests under Calcit 0.13.38. The main entry still has one pre-existing JS FFI return-type warning in `respo.comp.inspect/gen%`, unrelated to this change.