### PR TITLE
chore: release 0.16.85

### DIFF
--- a/deps.cirru
+++ b/deps.cirru
@@ -1,4 +1,4 @@
 
 {} (:calcit-version |0.13.40)
-  :version |0.16.84
+  :version |0.16.85
   :dependencies $ {} (|calcit-lang/js-ffi |0.1.9)


### PR DESCRIPTION
Publishes the Calcit 0.13.40-compatible respo core now on main. Local tests and check-only validation pass.