### PR TITLE
fix: return unit from Respo effect paths

### DIFF
--- a/calcit.cirru
+++ b/calcit.cirru
@@ -2243,10 +2243,15 @@
                         warn-style-literals value
                         recur $ inc idx
                   , &unit
+                , &unit
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Unit)
               :args $ [] 'Dynamic
+          :tests $ []
+            %{} 'TestEntry (:name |returns-unit-for-non-enum)
+              :code $ quote
+                assert= &unit $ warn-style-literals |plain
       :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns respo.css $ :require

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -707,7 +707,7 @@
                     do
                       if (js-present? js/window.devtoolsFormatters) (js/console.log data)
                         js/console.log $ to-js-data data
-                      , nil
+                      , &unit
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'respo.schema/Component)
@@ -795,7 +795,7 @@
                   listener-builder $ fn (event-name) (build-listener event-name deliver-event)
                 set! (.-innerHTML mount-point) |
                 .!appendChild mount-point $ make-element entire-dom listener-builder ([])
-              ;nil
+              do &unit
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Unit)
@@ -1759,7 +1759,7 @@
                 fn () $ do
                   when (not @*queued?) (reset! *queued? true)
                     queue! $ fn () (reset! *queued? false) (render-fn)
-                  , nil
+                  , &unit
           :examples $ []
             quote $ make-render-scheduler
               fn () nil
@@ -1943,7 +1943,7 @@
         |rerender-app! $ %{} 'CodeEntry (:doc "|Diffs the new element against the global element and patches the DOM. Used internally by render!.")
           :code $ quote
             defn rerender-app! (target element *dispatch-fn)
-              if (identical? @*global-element element) nil $ let
+              if (identical? @*global-element element) &unit $ let
                   deliver-event $ build-deliver-event *global-element *dispatch-fn
                   changes $ &buf-list:new
                   collect! $ fn (op) (&buf-list:push changes op)
@@ -2234,7 +2234,7 @@
                       idx 1
                     if
                       >= idx $ count x
-                      , nil $ let
+                      , &unit $ let
                           pair $ option:unwrap (nth x idx)
                           value $ option:unwrap (nth pair 1)
                         when
@@ -2242,7 +2242,7 @@
                           println "|[Respo] defstyle warning: CSS value has extra tokens. In Cirru, an unquoted multi-word CSS value is parsed as multiple AST nodes; use a quoted string such as |0 auto or |1px solid ... ."
                         warn-style-literals value
                         recur $ inc idx
-                  , nil
+                  , &unit
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Unit)
@@ -3303,9 +3303,9 @@
               let
                   was-empty? $ empty? old-style
                   now-empty? $ empty? new-style
-                if (identical? old-style new-style) nil $ cond
+                if (identical? old-style new-style) &unit $ cond
                     and was-empty? now-empty?
-                    , nil
+                    , &unit
                   (and was-empty? (not now-empty?))
                     let
                         entry $ option:unwrap (first new-style)
@@ -3898,7 +3898,7 @@
                 ->
                   unsafe-coerce (.-parentElement target) JsObject
                   .!insertBefore new-element target
-              ;nil
+              do &unit
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Unit)
@@ -3943,7 +3943,7 @@
                 aset
                   unsafe-coerce (.-style target) JsObject
                   , style-name style-value
-              ;nil
+              do &unit
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Unit)
@@ -3955,7 +3955,7 @@
               &let
                 new-element $ make-element op listener-builder coord
                 .append-child! target new-element
-              ;nil
+              do &unit
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Unit)
@@ -3969,7 +3969,9 @@
                 &doseq (op changes)
                   let-sugar
                       n-coord $ option:unwrap (nth op 2)
-                      target $ find-target (get-root) n-coord
+                      target $ find-target
+                        unsafe-coerce (get-root) 'respo.dom/DomElement
+                        , n-coord
                     match op
                       (:replace-prop _coord _n-coord op-data)
                         replace-prop target
@@ -4031,7 +4033,7 @@
                   unsafe-coerce (.-parentElement target) JsObject
                   .!insertBefore new-element target
                 .!remove target
-              ;nil
+              do &unit
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Unit)
@@ -4057,7 +4059,7 @@
                         not= prop-value $ .-value target
                         js-set target prop-name prop-value
                       js-set target prop-name prop-value
-                ;nil
+                do &unit
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Unit)
@@ -4071,7 +4073,7 @@
                 aset
                   unsafe-coerce (.-style target) JsObject
                   , style-name $ get-style-value v style-name
-              ;nil
+              do &unit
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Unit)
@@ -4081,7 +4083,7 @@
           :code $ quote
             defn rm-element (target op)
               if (some? target) (.remove! target) (js/console.warn "|Respo: Element already removed! Probably by :inner-text.")
-              ;nil
+              do &unit
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Unit)
@@ -4091,7 +4093,7 @@
             defn rm-event (target event-name)
               &let
                 event-prop $ event->prop event-name
-                js-set target event-prop nil
+                do (js-set target event-prop nil) &unit
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Unit)
@@ -4126,7 +4128,9 @@
             defn rm-style (target op)
               &let
                 style-name $ dashed->camel (turn-string op)
-                -> (.-style target) (js-set style-name nil)
+                do
+                  -> (.-style target) (js-set style-name nil)
+                  , &unit
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Unit)
@@ -4445,7 +4449,7 @@
           :examples $ []
           :schema $ :: 'Enum
         |EventHandler $ %{} 'CodeEntry (:doc "|Event callback signature. Respo delivers an immutable map produced by event->edn together with the application dispatch function.")
-          :code $ quote (def EventHandler nil)
+          :code $ quote (def EventHandler &unit)
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Unit)
@@ -4574,7 +4578,7 @@
               js/setTimeout
                 fn () $ assert |all-async-checks-ran (= 3 @*async-checks)
                 , 0
-              , nil
+              , &unit
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Unit)

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -4166,7 +4166,7 @@
         |ResourceState $ %{} 'CodeEntry (:doc "|Immutable resource state record. :data and :error are application payload boundaries; :status and :request-id drive deterministic reducer transitions.")
           :code $ quote
             defstruct ResourceState (:status 'Tag)
-              :request-id $ :: 'Optional 'Number
+              :request-id $ :: 'Option 'Number
               :data 'Dynamic
               :error 'Dynamic
           :examples $ []
@@ -4234,7 +4234,8 @@
         |resource-idle $ %{} 'CodeEntry (:doc "|Creates an immutable idle ResourceState with optional initial data.")
           :code $ quote
             defn resource-idle (initial-data-option)
-              %{} ResourceState (:status :idle) (:request-id nil)
+              %{} ResourceState (:status :idle)
+                :request-id $ %none
                 :data $ option:unwrap-or initial-data-option nil
                 :error nil
           :examples $ []
@@ -4286,18 +4287,22 @@
                       if
                         or (= :ready status) (= :refreshing status)
                         , :refreshing :pending
-                    :request-id request-id
+                    :request-id $ %some request-id
                     :data $ :data state
                     :error nil
                 (:ready request-id data)
                   if
-                    = (:request-id state) request-id
-                    %{} ResourceState (:status :ready) (:request-id request-id) (:data data) (:error nil)
+                    = (:request-id state) (%some request-id)
+                    %{} ResourceState (:status :ready)
+                      :request-id $ %some request-id
+                      :data data
+                      :error nil
                     , state
                 (:failed request-id error)
                   if
-                    = (:request-id state) request-id
-                    %{} ResourceState (:status :error) (:request-id request-id)
+                    = (:request-id state) (%some request-id)
+                    %{} ResourceState (:status :error)
+                      :request-id $ %some request-id
                       :data $ :data state
                       :error error
                     , state
@@ -4338,6 +4343,19 @@
                     {} $ :value |first
                     &struct:nth failed 0 :data
                   assert |nil-data-can-refresh $ = :refreshing (&struct:nth refreshing-nil 3 :status)
+            %{} 'TestEntry (:name |stores-request-id-as-option)
+              :code $ quote
+                let
+                    idle $ resource-idle (%none)
+                    pending $ resource-reducer idle (resource-started 7)
+                    ready $ resource-reducer pending (resource-ready 7 |ok)
+                    failed $ resource-reducer pending (resource-failed 7 |offline)
+                    stale $ resource-reducer pending (resource-ready 8 |stale)
+                  assert= (%none) (&struct:nth idle 2 :request-id)
+                  assert= (%some 7) (&struct:nth pending 2 :request-id)
+                  assert= (%some 7) (&struct:nth ready 2 :request-id)
+                  assert= (%some 7) (&struct:nth failed 2 :request-id)
+                  assert |stale-result-keeps-option-state $ identical? pending stale
         |resource-started $ %{} 'CodeEntry (:doc "|Creates a :started ResourceAction for a numeric request id.")
           :code $ quote
             defn resource-started (request-id)

--- a/deps.cirru
+++ b/deps.cirru
@@ -1,4 +1,4 @@
 
-{} (:calcit-version |0.13.40)
+{} (:calcit-version |0.13.44)
   :version |0.16.85
-  :dependencies $ {} (|calcit-lang/js-ffi |0.1.9)
+  :dependencies $ {} (|calcit-lang/js-ffi |0.1.10)

--- a/history/202608251744-resource-request-id-option.md
+++ b/history/202608251744-resource-request-id-option.md
@@ -1,0 +1,7 @@
+# Resource request id uses nominal Option
+
+- Migrated `ResourceState.request-id` from legacy nullable `Optional<Number>` to `Option<Number>`.
+- Idle state stores `%none`; active, ready, and failed states store `%some request-id`.
+- Stale response comparison now compares the state option with `%some request-id`.
+- Added reducer coverage for idle, pending, ready, failed, and stale transitions.
+- DOM props, component tree placeholders, refs, and event normalization remain unchanged compatibility boundaries.

--- a/history/202608251754-warn-style-unit-review.md
+++ b/history/202608251754-warn-style-unit-review.md
@@ -1,0 +1,5 @@
+# Preserve Unit for non-enum style literals
+
+- Added the missing outer `if` fallback in `warn-style-literals`.
+- Non-enum inputs now return canonical `&unit` instead of legacy nil.
+- Added a definition test for the non-enum runtime path.

--- a/history/202608251850-upgrade-calcit-01344.md
+++ b/history/202608251850-upgrade-calcit-01344.md
@@ -1,0 +1,5 @@
+# Upgrade to Calcit 0.13.44
+
+- Require Calcit and `@calcit/procs` 0.13.44 for canonical Unit support.
+- Upgrade `calcit-lang/js-ffi` to 0.1.10 so effect helpers expose Unit consistently.
+- Validate type checks, 27 runtime tests, all 111 documentation blocks, generated JavaScript, and the production build.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@calcit/procs": "0.13.40"
+    "@calcit/procs": "0.13.44"
   },
   "scripts": {
     "test": "calcit calcit.cirru test --require-match --summary-only --format json",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,14 +5,14 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@calcit/procs@npm:0.13.40":
-  version: 0.13.40
-  resolution: "@calcit/procs@npm:0.13.40"
+"@calcit/procs@npm:0.13.44":
+  version: 0.13.44
+  resolution: "@calcit/procs@npm:0.13.44"
   dependencies:
     "@calcit/ternary-tree": "npm:0.0.26"
     "@cirru/parser.ts": "npm:^0.0.9"
     "@cirru/writer.ts": "npm:^0.1.9"
-  checksum: 10c0/026aea886fd950050ec3e08237da00a9dc2a2e5a9d8849ab36f85b17f6c367806cada9e422e5fdd28657e0ec2bdd4d783e8724dcc69ced7fecdfb0faf000230c
+  checksum: 10c0/eff75aaf48606f66ec301bba87eca71ccb89e034351b89bea69636433cb08a970a56cf72c830309f7524f8c86443195fd04d3be0d3cefac6b2f3bbab8fa8c62c
   languageName: node
   linkType: hard
 
@@ -931,7 +931,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    "@calcit/procs": "npm:0.13.40"
+    "@calcit/procs": "npm:0.13.44"
     bottom-tip: "npm:^0.1.5"
     vite: "npm:^8.2.0"
   languageName: unknown


### PR DESCRIPTION
## Summary
- replace Nil and legacy ;nil tails with canonical &unit in Unit-declared render and DOM effects
- keep intentional JS null writes and DOM absence behavior unchanged
- make scheduler, diff, style, and test completion paths return Unit consistently
- preserve the trusted get-root DOM boundary with an explicit narrow coercion
- migrate ResourceState.request-id from Optional<Number>/nil to Option<Number>
- keep DOM props, component tree placeholders, refs, and event normalization as reviewed compatibility boundaries

## Validation
- check-only with local js-ffi and Calcit
- 26 of 26 definition tests
- generated-JS Node runtime test, including ResourceState %none/%some transitions
- Vite production build
- Recollect static, unit, JS, and production-build regression suite
- zero declared-unit nil findings

Depends on calcit-lang/js-ffi#4 and is part of calcit-lang/calcit#428 and calcit-lang/calcit#431.