### PR TITLE
chore: release 0.16.86

### DIFF
--- a/deps.cirru
+++ b/deps.cirru
@@ -1,4 +1,4 @@
 
 {} (:calcit-version |0.13.44)
-  :version |0.16.85
+  :version |0.16.86
   :dependencies $ {} (|calcit-lang/js-ffi |0.1.10)

--- a/history/202608251855-release-01686.md
+++ b/history/202608251855-release-01686.md
@@ -1,0 +1,5 @@
+# Release 0.16.86
+
+- Return canonical Unit from Respo effect paths on Calcit 0.13.44.
+- Model resource request IDs with `Option` while preserving request lifecycle behavior.
+- Require js-ffi 0.1.10 for consistent FFI Unit contracts.


### PR DESCRIPTION
Release Respo 0.16.86 after the Calcit 0.13.44 and js-ffi 0.1.10 upgrades.\n\nValidation: check-only, 27/27 runtime tests, generated JavaScript, and Vite production build.