### PR TITLE
refactor: add strict macro contracts

### DIFF
--- a/calcit.cirru
+++ b/calcit.cirru
@@ -1225,7 +1225,11 @@
             quote $ defcomp comp-with-effect (value)
               [] (effect-log value)
                 div ({}) (<> value)
-          :schema $ :: 'Dynamic
+          :schema $ :: 'Macro
+            {} (:rest 'Syntax)
+              :capabilities $ #{}
+              :expansion $ :: 'Definition 'Fn
+              :required $ [] 'SyntaxSymbol 'SyntaxList
         |defeffect $ %{} 'CodeEntry (:doc "|Macro for defining component effects.\n\nThe generated effect receives lifecycle information such as `action`, the root element, and `at-place?`, and is typically used inside a component effect vector like `[] (effect ...) child-tree`.\n\nSupported actions are `:mount`, `:before-update`, `:update`, and `:unmount`.")
           :code $ quote
             defmacro defeffect (effect-name args params & body)
@@ -1248,7 +1252,11 @@
           :examples $ []
             quote $ defeffect log-message (message) (action el at-place?)
               if (= action :mount) (js/console.log message)
-          :schema $ :: 'Dynamic
+          :schema $ :: 'Macro
+            {} (:rest 'Syntax)
+              :capabilities $ #{}
+              :expansion $ :: 'Definition 'Fn
+              :required $ [] 'SyntaxSymbol 'SyntaxList 'SyntaxList
         |defplugin $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defmacro defplugin (x params & body)
@@ -1257,7 +1265,11 @@
               assert "|expected some result" $ > (count body) 0
               quasiquote $ defn ~x ~params ~@body
           :examples $ []
-          :schema $ :: 'Dynamic
+          :schema $ :: 'Macro
+            {} (:rest 'Syntax)
+              :capabilities $ #{}
+              :expansion $ :: 'Definition 'Fn
+              :required $ [] 'SyntaxSymbol 'SyntaxList
         |div $ %{} 'CodeEntry (:doc "|Create a `<div>` virtual element.\n\nThe first argument is an optional props map. Remaining arguments are child nodes. Put DOM props such as `:class-name`, `:style`, and event handlers in the props map.")
           :code $ quote
             defn div (props & children) (create-element :div props & children)
@@ -1530,7 +1542,12 @@
               fn (_error)
                 div ({}) (<> |Failed)
               div ({}) (<> |Ready)
-          :schema $ :: 'Dynamic
+          :schema $ :: 'Macro
+            {}
+              :capabilities $ #{}
+              :expansion $ :: 'Expr 'Dynamic
+              :required $ [] (:: 'Expr 'Fn)
+              :rest $ :: 'Expr 'Dynamic
           :tests $ []
             %{} 'TestEntry (:name |catches-render-errors)
               :code $ quote
@@ -2000,7 +2017,12 @@
             quote $ show true
               div ({}) (<> |Ready)
               div ({}) (<> |Loading)
-          :schema $ :: 'Dynamic
+          :schema $ :: 'Macro
+            {}
+              :capabilities $ #{}
+              :expansion $ :: 'Expr 'Dynamic
+              :required $ [] (:: 'Expr 'Dynamic)
+              :rest $ :: 'Expr 'Dynamic
           :tests $ []
             %{} 'TestEntry (:name |selects-one-branch)
               :code $ quote
@@ -2187,7 +2209,10 @@
                 |& $ {} (:font-size |14px) (:line-height |1.6) (:color "|hsl(0,0%,20%)")
                 |&::before $ {} (:content "|\"→ \"")
           :schema $ :: 'Macro
-            {} $ :args ([] 'Symbol 'List)
+            {}
+              :capabilities $ #{} :log
+              :expansion $ :: 'Expr 'String
+              :required $ [] 'SyntaxSymbol 'SyntaxList
         |detect-nodejs? $ %{} 'CodeEntry (:doc "|Detects Node.js behind an explicit JavaScript FFI function so nodejs? remains a Boolean value.")
           :code $ quote
             defn detect-nodejs? () $ and (exists? js/process) (= js/process.release.name |node)

--- a/deps.cirru
+++ b/deps.cirru
@@ -1,4 +1,4 @@
 
-{} (:calcit-version |0.13.44)
+{} (:calcit-version |0.13.45)
   :version |0.16.86
   :dependencies $ {} (|calcit-lang/js-ffi |0.1.10)

--- a/history/20260826-strict-macro-contracts.md
+++ b/history/20260826-strict-macro-contracts.md
@@ -1,0 +1,8 @@
+# Strict macro contracts
+
+- Migrated all six Respo macros to phase-aware signatures using Calcit 0.13.45.
+- Definition generators require symbol/list syntax and expand to function definitions.
+- `error-boundary` requires a callable fallback; `show` keeps its deliberately dynamic branch values.
+- `defstyle` requires symbol/list syntax, expands to a string expression, and declares `:log` because style-literal warnings may print during macro expansion.
+- Upgraded both `deps.cirru :calcit-version` and `@calcit/procs` to 0.13.45.
+- Verified 27/27 attached tests, 126/126 documentation snippets, native check-only, and JS generation with the published compiler.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@calcit/procs": "0.13.44"
+    "@calcit/procs": "0.13.45"
   },
   "scripts": {
     "test": "calcit calcit.cirru test --require-match --summary-only --format json",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,14 +5,14 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@calcit/procs@npm:0.13.44":
-  version: 0.13.44
-  resolution: "@calcit/procs@npm:0.13.44"
+"@calcit/procs@npm:0.13.45":
+  version: 0.13.45
+  resolution: "@calcit/procs@npm:0.13.45"
   dependencies:
     "@calcit/ternary-tree": "npm:0.0.26"
     "@cirru/parser.ts": "npm:^0.0.9"
     "@cirru/writer.ts": "npm:^0.1.9"
-  checksum: 10c0/eff75aaf48606f66ec301bba87eca71ccb89e034351b89bea69636433cb08a970a56cf72c830309f7524f8c86443195fd04d3be0d3cefac6b2f3bbab8fa8c62c
+  checksum: 10c0/f6ad58c36099149a7717763e1c6d0b1b04fea2ae783cb2b10bbe9931eaf89869fef89f2bde34c200fd8e24f829605a55d0db34cd04369e5f74fd3d11059cd225
   languageName: node
   linkType: hard
 
@@ -931,7 +931,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    "@calcit/procs": "npm:0.13.44"
+    "@calcit/procs": "npm:0.13.45"
     bottom-tip: "npm:^0.1.5"
     vite: "npm:^8.2.0"
   languageName: unknown


### PR DESCRIPTION
## Summary

- migrate all six Respo macros to strict phase-aware contracts
- classify `defcomp`, `defeffect`, and `defplugin` as function-definition generators with symbol/list syntax inputs
- require a callable fallback for `error-boundary` and preserve deliberate dynamic branch values in `show`
- classify `defstyle` as `Expr<String>` and declare `:log` for compile-time style warnings
- upgrade both `deps.cirru :calcit-version` and `@calcit/procs` to published Calcit 0.13.45

## Safety and performance

- malformed names, parameter lists, and fallback functions now fail at the macro boundary with structured syntax/type diagnostics
- compile-time `defstyle` warnings are explicitly cache-ineligible, so a future macro cache cannot suppress observable warning output
- pure Respo macro expansions become eligible for the planned cache, but Calcit 0.13.45 still has zero cache hits because caching is not implemented; this PR does not claim an immediate speedup

## Verification

- `calcit calcit.cirru --check-only --macro-metrics`
- `yarn test`: 27/27 passed
- `yarn check-docs`: 35 files and 126/126 snippets passed
- `calcit calcit.cirru js`
- `caps verify`: 1 module verified
