### PR TITLE
chore: release 0.16.87

### DIFF
--- a/deps.cirru
+++ b/deps.cirru
@@ -1,4 +1,4 @@
 
-{} (:calcit-version |0.13.45)
-  :version |0.16.86
+{} (:calcit-version |0.13.51)
+  :version |0.16.87
   :dependencies $ {} (|calcit-lang/js-ffi |0.1.10)

--- a/history/202608271452-release-01687.md
+++ b/history/202608271452-release-01687.md
@@ -1,0 +1,5 @@
+# Release 0.16.87
+
+- Publish strict macro contracts for `defcomp`, `defeffect`, `defplugin`, `error-boundary`, `show`, and `defstyle`.
+- Upgrade the Calcit toolchain and JavaScript runtime to 0.13.51.
+- Verify the dependency-aware legacy macro schema inventory is zero for Respo itself.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@calcit/procs": "0.13.45"
+    "@calcit/procs": "0.13.51"
   },
   "scripts": {
     "test": "calcit calcit.cirru test --require-match --summary-only --format json",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,14 +5,14 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@calcit/procs@npm:0.13.45":
-  version: 0.13.45
-  resolution: "@calcit/procs@npm:0.13.45"
+"@calcit/procs@npm:0.13.51":
+  version: 0.13.51
+  resolution: "@calcit/procs@npm:0.13.51"
   dependencies:
     "@calcit/ternary-tree": "npm:0.0.26"
     "@cirru/parser.ts": "npm:^0.0.9"
     "@cirru/writer.ts": "npm:^0.1.9"
-  checksum: 10c0/f6ad58c36099149a7717763e1c6d0b1b04fea2ae783cb2b10bbe9931eaf89869fef89f2bde34c200fd8e24f829605a55d0db34cd04369e5f74fd3d11059cd225
+  checksum: 10c0/a83022d613374aac8e648ff9213a011d18ffe204607fece9ba9d7bccbc022e09eb028dbb74589a3c2a7c5aeeb76eb368f058d08d072b9ca4ad45fc4693cdfa00
   languageName: node
   linkType: hard
 
@@ -931,7 +931,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    "@calcit/procs": "npm:0.13.45"
+    "@calcit/procs": "npm:0.13.51"
     bottom-tip: "npm:^0.1.5"
     vite: "npm:^8.2.0"
   languageName: unknown


### PR DESCRIPTION
## Summary

- release the strict macro contracts merged in #119
- upgrade Calcit and @calcit/procs to 0.13.51
- bump the Respo module version to 0.16.87

## Validation

- Calcit 0.13.51 check-only
- dependency-aware check-types: legacy_macro_schemas = 0
- 27/27 definition-attached native tests
- 111/111 Markdown blocks
- JavaScript codegen and Vite production build
- yarn install --immutable with @calcit/procs 0.13.51 from the public npm registry